### PR TITLE
Moved all procedural Drupal function calls to DrupalHandler utility

### DIFF
--- a/src/Drupal/Translatable/FieldCollectionTranslatable.php
+++ b/src/Drupal/Translatable/FieldCollectionTranslatable.php
@@ -23,16 +23,16 @@ class FieldCollectionTranslatable extends EntityTranslatableBase {
     if (!isset($this->targetEntities[$targetLanguage]) || empty($this->targetEntities[$targetLanguage])) {
       // Handling for content translation. Entity field translation should be
       // taken care of by the parent.
-      if (!$this->moduleExists('entity_translation')) {
+      if (!$this->drupal->moduleExists('entity_translation')) {
         $target = $this->entity->raw();
         if (!is_object($target) && !empty($target)) {
-          $target = $this->entityLoad('field_collection_item', array((int) $target));
+          $target = $this->drupal->entityLoad('field_collection_item', array((int) $target));
           $target = reset($target);
         }
 
         // Pull the parent/host entity.
         if ($rawHost = $this->getHostEntity($target)) {
-          $host = $this->entityMetadataWrapper($target->hostEntityType(), $rawHost);
+          $host = $this->drupal->entityMetadataWrapper($target->hostEntityType(), $rawHost);
         }
         else {
           $host = $this->getParent($this->entity);
@@ -55,7 +55,7 @@ class FieldCollectionTranslatable extends EntityTranslatableBase {
           $target->default_revision = TRUE;
         }
 
-        $this->targetEntities[$targetLanguage] = $this->entityMetadataWrapper('field_collection_item', $target);
+        $this->targetEntities[$targetLanguage] = $this->drupal->entityMetadataWrapper('field_collection_item', $target);
       }
       else {
         $this->targetEntities[$targetLanguage] = parent::getTargetEntity($targetLanguage);
@@ -80,40 +80,12 @@ class FieldCollectionTranslatable extends EntityTranslatableBase {
   public function getHostEntity(\FieldCollectionItemEntity $fieldCollection) {
     // Pull the parent/host entity with the maximum user privilege possible.
     $tempUser = clone $GLOBALS['user'];
-    $this->drupalSaveSession(FALSE);
-    $GLOBALS['user'] = user_load(1);
+    $this->drupal->saveSession(FALSE);
+    $GLOBALS['user'] = $this->drupal->userLoad(1);
     $rawHost = $fieldCollection->hostEntity();
     $GLOBALS['user'] = $tempUser;
-    $this->drupalSaveSession(TRUE);
+    $this->drupal->saveSession(TRUE);
     return $rawHost;
-  }
-
-  /**
-   * OO wrapper around module_exists().
-   *
-   * @param string $module
-   *   The name of the module (without the .module extension).
-   *
-   * @return bool
-   *   TRUE if the module is both installed and enabled, FALSE otherwise.
-   */
-  protected function moduleExists($module) {
-    return module_exists($module);
-  }
-
-  /**
-   * OO wrapper around drupal_save_session().
-   * @param bool $status
-   */
-  protected function drupalSaveSession($status = NULL) {
-    return drupal_save_session($status);
-  }
-
-  /**
-   * OO wrapper around entity_load().
-   */
-  protected function entityLoad($entity_type, $ids = FALSE, $conditions = array(), $reset = FALSE) {
-    return entity_load($entity_type, $ids, $conditions, $reset);
   }
 
 }

--- a/src/Drupal/Translatable/NodeTranslatable.php
+++ b/src/Drupal/Translatable/NodeTranslatable.php
@@ -7,6 +7,9 @@
 
 namespace EntityXliff\Drupal\Translatable;
 
+use EntityXliff\Drupal\Utils\DrupalHandler;
+
+
 /**
  * Class NodeTranslatable
  * @package EntityXliff\Drupal\Translatable
@@ -30,24 +33,25 @@ class NodeTranslatable extends EntityTranslatableBase {
    *   translation is in use. If no translation set is provided, a default will
    *   be provided by translation_node_get_translations().
    */
-  public function __construct(\EntityDrupalWrapper $entityWrapper, array $entityInfo = array(), array $translationSet = array()) {
-    parent::__construct($entityWrapper, $entityInfo);
+  public function __construct(\EntityDrupalWrapper $entityWrapper, DrupalHandler $handler = NULL, array $entityInfo = array(), array $translationSet = array()) {
+    parent::__construct($entityWrapper, $handler, $entityInfo);
 
     // Handle content translation for nodes.
-    $this->drupalStaticReset('translation_node_get_translations');
+    $this->drupal->staticReset('translation_node_get_translations');
     if ($entityWrapper->language->value() === 'en') {
       $this->tset = $translationSet ?: $this->nodeGetTranslations((int) $entityWrapper->getIdentifier());
     }
     else {
       $raw = $entityWrapper->raw();
       if (!is_object($raw)) {
-        $raw = $this->nodeLoad((int) $raw);
+        $raw = $this->drupal->nodeLoad((int) $raw);
       }
       $this->tset = $translationSet ?: $this->nodeGetTranslations((int) $raw->tnid);
     }
   }
 
   /**
+   * @param \EntityDrupalWrapper $wrapper
    * @return array
    */
   public function getTranslatableFields(\EntityDrupalWrapper $wrapper = NULL) {
@@ -55,7 +59,7 @@ class NodeTranslatable extends EntityTranslatableBase {
     $type = $wrapper->type();
 
     // Only add the title property if we're using content translation.
-    if ($type === 'node' && !$this->moduleExists('entity_translation')) {
+    if ($type === 'node' && !$this->drupal->moduleExists('entity_translation')) {
       $fields[] = 'title';
     }
 
@@ -69,10 +73,10 @@ class NodeTranslatable extends EntityTranslatableBase {
     if (!isset($this->targetEntities[$targetLanguage]) || empty($this->targetEntities[$targetLanguage])) {
       // Handling for content translation. Entity field translation should be
       // taken care of by the parent. @todo check if that assumption is legit.
-      if (!$this->moduleExists('entity_translation')) {
+      if (!$this->drupal->moduleExists('entity_translation')) {
         // If a translation already exists, use it!
         if (isset($this->tset[$targetLanguage]->nid)) {
-          $target = $this->nodeLoad($this->tset[$targetLanguage]->nid, NULL, TRUE);
+          $target = $this->drupal->nodeLoad($this->tset[$targetLanguage]->nid, NULL, TRUE);
 
           // Do not mark this node as a new revision. This is necessary in
           // cases where this node happens to reference a field collection...
@@ -85,7 +89,7 @@ class NodeTranslatable extends EntityTranslatableBase {
 
           $target = $this->entity->raw();
           if (!is_object($target) && !empty($target)) {
-            $target = $this->nodeLoad((int) $target, NULL, TRUE);
+            $target = $this->drupal->nodeLoad((int) $target, NULL, TRUE);
           }
           $target->translation_source = clone $target;
 
@@ -95,7 +99,7 @@ class NodeTranslatable extends EntityTranslatableBase {
           $target->language = $targetLanguage;
         }
 
-        $this->targetEntities[$targetLanguage] = $this->entityMetadataWrapper('node', $target);
+        $this->targetEntities[$targetLanguage] = $this->drupal->entityMetadataWrapper('node', $target);
       }
       else {
         $this->targetEntities[$targetLanguage] = parent::getTargetEntity($targetLanguage);
@@ -114,13 +118,13 @@ class NodeTranslatable extends EntityTranslatableBase {
    */
   protected function initializeContentTranslation() {
     $nid = (int) $this->entity->getIdentifier();
-    $source = $this->nodeLoad($nid, NULL, TRUE);
-    if ($source->language === LANGUAGE_NONE || empty($source->tnid)) {
+    $source = $this->drupal->nodeLoad($nid, NULL, TRUE);
+    if ($source->language === DrupalHandler::LANGUAGE_NONE || empty($source->tnid)) {
       $source->tnid = $nid;
       $source->language = 'en';
-      $this->nodeSave($source);
-      $this->entity = $this->entityMetadataWrapper('node', $source);
-      $this->drupalStaticReset('translation_node_get_translations');
+      $this->drupal->nodeSave($source);
+      $this->entity = $this->drupal->entityMetadataWrapper('node', $source);
+      $this->drupal->staticReset('translation_node_get_translations');
     }
   }
 
@@ -135,60 +139,12 @@ class NodeTranslatable extends EntityTranslatableBase {
     // a translation set happens to be unpublished, we still want to know about
     // it so we can update/override it (rather than creating a new one).
     $tempUser = clone $GLOBALS['user'];
-    $this->drupalSaveSession(FALSE);
-    $GLOBALS['user'] = user_load(1);
-    $tset = translation_node_get_translations($tnid);
+    $this->drupal->saveSession(FALSE);
+    $GLOBALS['user'] = $this->drupal->userLoad(1);
+    $tset = $this->drupal->translationNodeGetTranslations($tnid);
     $GLOBALS['user'] = $tempUser;
-    $this->drupalSaveSession(TRUE);
+    $this->drupal->saveSession(TRUE);
     return $tset;
-  }
-
-  /**
-   * OO wrapper around node_load().
-   * @param null $nid
-   * @param null $vid
-   * @param bool $reset
-   */
-  protected function nodeLoad($nid = NULL, $vid = NULL, $reset = FALSE) {
-    return node_load($nid, $vid, $reset);
-  }
-
-  /**
-   * OO wrapper around node_save().
-   * @param $node
-   * @throws \Exception
-   */
-  protected function nodeSave($node) {
-    node_save($node);
-  }
-
-  /**
-   * OO wrapper around module_exists().
-   *
-   * @param string $module
-   *   The name of the module (without the .module extension).
-   *
-   * @return bool
-   *   TRUE if the module is both installed and enabled, FALSE otherwise.
-   */
-  protected function moduleExists($module) {
-    return module_exists($module);
-  }
-
-  /**
-   * OO wrapper around drupal_static_rest().
-   * @param string $name
-   */
-  protected function drupalStaticReset($name = NULL) {
-    drupal_static_reset($name);
-  }
-
-  /**
-   * OO wrapper around drupal_save_session().
-   * @param bool $status
-   */
-  protected function drupalSaveSession($status = NULL) {
-    return drupal_save_session($status);
   }
 
 }

--- a/src/Drupal/Utils/DrupalHandler.php
+++ b/src/Drupal/Utils/DrupalHandler.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * @file
+ * Contains the DrupalHandler class, which is a glorified OO wrapper around
+ * procedural Drupal functions that our code depends upon. This vastly
+ * simplifies unit testing.
+ */
+
+namespace EntityXliff\Drupal\Utils;
+
+
+class DrupalHandler {
+
+  CONST WATCHDOG_WARNING = 4;
+  CONST LANGUAGE_NONE = 'und';
+
+  /**
+   * Sets a value in a nested array with variable depth.
+   * @param array $array
+   * @param array $parents
+   * @param mixed $value
+   * @param bool $force
+   * @see drupal_array_set_nested_value()
+   */
+  public function arraySetNestedValue(array &$array, array $parents, $value, $force = FALSE) {
+    drupal_array_set_nested_value($array, $parents, $value, $force);
+  }
+
+  /**
+   * Identifies the children of an element array, optionally sorted by weight.
+   * @param array $elements
+   * @param bool $sort
+   * @return array
+   * @see element_children()
+   */
+  public function elementChildren(&$elements, $sort = FALSE) {
+    return element_children($elements, $sort);
+  }
+
+  /**
+   * Get the entity info array of an entity type.
+   * @param string $entityType
+   * @return array
+   * @see entity_get_info()
+   */
+  public function entityGetInfo($entityType = NULL) {
+    return entity_get_info($entityType);
+  }
+
+  /**
+   * Load entities from the database.
+   * @param $entity_type
+   * @param bool $ids
+   * @param array $conditions
+   * @param bool $reset
+   * @return mixed
+   * @see entity_load()
+   */
+  public function entityLoad($entity_type, $ids = FALSE, $conditions = array(), $reset = FALSE) {
+    return entity_load($entity_type, $ids, $conditions, $reset);
+  }
+
+  /**
+   * Returns a property wrapper for the given data.
+   * @param string $type
+   * @param mixed $data
+   * @param array $info
+   * @return \EntityMetadataWrapper
+   * @see entity_metadata_wrapper()
+   */
+  public function entityMetadataWrapper($type, $data = NULL, array $info = array()) {
+    return entity_metadata_wrapper($type, $data, $info);
+  }
+
+  /**
+   * Determines whether a given module exists.
+   * @param string $module
+   * @return bool
+   * @see module_exists()
+   */
+  public function moduleExists($module) {
+    return module_exists($module);
+  }
+
+  /**
+   * Loads a node object from the database.
+   * @param null $nid
+   * @param null $vid
+   * @param bool $reset
+   * @see node_load()
+   */
+  public function nodeLoad($nid = NULL, $vid = NULL, $reset = FALSE) {
+    return node_load($nid, $vid, $reset);
+  }
+
+  /**
+   * Saves changes to a node or adds a new node.
+   * @param object $node
+   * @throws \Exception
+   * @see node_save()
+   */
+  public function nodeSave($node) {
+    node_save($node);
+  }
+
+  /**
+   * Determines whether to save session data of the current request.
+   * @param bool $status
+   * @see drupal_save_session()
+   */
+  public function saveSession($status = NULL) {
+    return drupal_save_session($status);
+  }
+
+  /**
+   * Resets one or all centrally stored static variable(s).
+   * @param string $name
+   * @see drupal_static_reset()
+   */
+  public function staticReset($name = NULL) {
+    drupal_static_reset($name);
+  }
+
+  /**
+   * Gets all nodes in a given translation set.
+   * @param int $tnid
+   * @return array
+   * @see translation_node_get_translations
+   */
+  public function translationNodeGetTranslations($tnid) {
+    return translation_node_get_translations($tnid);
+  }
+
+  /**
+   * Loads a user object.
+   * @param int $uid
+   * @param bool $reset
+   * @return mixed
+   * @see user_load()
+   */
+  public function userLoad($uid, $reset = FALSE) {
+    return user_load($uid, $reset);
+  }
+  /**
+   * Logs a system message.
+   * @param $type
+   * @param $message
+   * @param array $variables
+   * @param null $severity
+   * @param null $link
+   * @see watchdog()
+   */
+  public function watchdog($type, $message, $variables = array(), $severity = NULL, $link = NULL) {
+    watchdog($type, $message, $variables, $severity, $link);
+  }
+
+}


### PR DESCRIPTION
This will:
- Dramatically simplify unit tests.
- Open up a possible solution for #4, where hook-based class declaration is possible via a module_invoke on the DrupalHandler utility class.
