### PR TITLE
Make entity translatable classes pluggable

### DIFF
--- a/entity_xliff.api.php
+++ b/entity_xliff.api.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @file
+ * Hook documentation for the Entity Xliff module.
+ *
+ * This file contains no working PHP code; it exists to provide additional
+ * documentation for doxygen as well as to document hooks in the standard
+ * Drupal manner.
+ */
+
+/**
+ * @defgroup entity_xliff Entity Xliff module integrations.
+ *
+ * Module integrations with the Entity Xliff module.
+ */
+
+
+/**
+ * @defgroup entity_xliff_hooks Entity Xliff's hooks
+ * @{
+ * Hooks that can be implemented by other modules in order to extend the Entity
+ * Xliff module.
+ */
+
+/**
+ * Return info about entities and the way in which they integrate with the
+ * Entity Xliff module.
+ *
+ * @return array
+ *   Returns an associative array of Entity Xliff translatable details, keyed by
+ *   entity type. At a bare minimum Entity Xliff translatable info must include
+ *   the following:
+ *   - class: Class that implements EggsCereal\Interfaces\TranslatableInterface,
+ *     describing how entities of this type can be imported/exported. If you
+ *     are providing a class, you may wish to study or extend from the
+ *     EntityXliff\Drupal\Translatable\EntityTranslatableBase abstract class.
+ */
+function hook_entity_xliff_translatable_info() {
+  $translatables['node'] = array(
+    'class' => 'NodeTranslatable',
+  );
+
+  // Example showing a namespace'd PHP class.
+  $translatables['my_entity'] = array(
+    'class' => 'NameSpace\Of\MyEntityTranslatable',
+  );
+
+  return $translatables;
+}
+
+/**
+ * Alter Entity Xliff translatable info before it's applied to an Entity's info.
+ *
+ * @param array $translatables
+ *   An associative array of Entity Xliff translatable details exactly as spec'd
+ *   in hook_entity_xliff_translatable_info().
+ */
+function hook_entity_xliff_translatable_info_alter(&$translatables) {
+  $translatables['node']['class'] = 'MyCustomNodeTranslatable';
+}
+
+/**
+ * @}
+ */

--- a/entity_xliff.module
+++ b/entity_xliff.module
@@ -5,8 +5,7 @@
  * Module hooks and functions for the Entity XLIFF module.
  */
 
-use EntityXliff\Drupal\Translatable\NodeTranslatable;
-use EntityXliff\Drupal\Mediator\Entity as EntityMediator;
+use EntityXliff\Drupal\Mediator\EntityMediator;
 
 /**
  * Implements hook_menu().

--- a/entity_xliff.module
+++ b/entity_xliff.module
@@ -6,6 +6,7 @@
  */
 
 use EntityXliff\Drupal\Translatable\NodeTranslatable;
+use EntityXliff\Drupal\Mediator\Entity as EntityMediator;
 
 /**
  * Implements hook_menu().
@@ -53,6 +54,24 @@ function entity_xliff_permission() {
 }
 
 /**
+ * Implements hook_entity_info_alter().
+ */
+function entity_xliff_entity_info_alter(&$entityInfo) {
+  // Load our provided default implementations.
+  _entity_xliff_load_provided_incs();
+
+  // Return a list of translatable info (classes) keyed by entity type.
+  $translatables = module_invoke_all('entity_xliff_translatable_info');
+  drupal_alter('entity_xliff_translatable_info', $translatables);
+
+  foreach ($translatables as $type => $info) {
+    if (isset($entityInfo[$type]) && isset($info['class'])) {
+      $entityInfo[$type]['entity xliff translatable class'] = $info['class'];
+    }
+  }
+}
+
+/**
  * Gets a TranslatableInterface instance given an entity wrapper.
  *
  * @param \EntityDrupalWrapper $wrapper
@@ -61,16 +80,20 @@ function entity_xliff_permission() {
  * @return EggsCereal\Interfaces\TranslatableInterface|null
  *   Returns a translatable object compatible with Eggs'n'Cereal's Translatable
  *   interface. If none is known, NULL is returned.
- *
- * @todo This should eventually be hook-driven, so modules declaring custom
- * entity types that we aren't aware of can provide their own implementations.
- * This should also feed into the EntityTranslatableBase class itself.
  */
 function entity_xliff_get_translatable($wrapper) {
-  switch ($wrapper->type()) {
-    case 'node':
-      return new NodeTranslatable($wrapper);
+  $entityMediator = &drupal_static(__FUNCTION__, FALSE);
+  if ($entityMediator === FALSE) {
+    $entityMediator = new EntityMediator();
   }
+  return $entityMediator->getTranslatable($wrapper);
+}
 
-  return NULL;
+/**
+ * Loads in includes provided on behalf of existing modules.
+ */
+function _entity_xliff_load_provided_incs() {
+  foreach (array('node', 'field_collection') as $entity) {
+    module_load_include('inc', 'entity_xliff', 'modules/' . $entity . '.entity_xliff');
+  }
 }

--- a/modules/field_collection.entity_xliff.inc
+++ b/modules/field_collection.entity_xliff.inc
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @file
+ * Hooks implemented on behalf of the Field Collection module to integrate with
+ * Entity Xliff.
+ */
+
+
+if (!function_exists('field_collection_entity_xliff_translatable_info')) {
+
+  /**
+   * Implements hook_entity_xliff_translatable_info().
+   */
+  function field_collection_entity_xliff_translatable_info() {
+    return array(
+      'field_collection_item' => array(
+        'class' => 'EntityXliff\Drupal\Translatable\FieldCollectionTranslatable',
+      ),
+    );
+  }
+
+}

--- a/modules/node.entity_xliff.inc
+++ b/modules/node.entity_xliff.inc
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @file
+ * Hooks implemented on behalf of the Node module to integrate with
+ * Entity Xliff.
+ */
+
+if (!function_exists('node_entity_xliff_translatable_info')) {
+
+  /**
+   * Implements hook_entity_xliff_translatable_info().
+   */
+  function node_entity_xliff_translatable_info() {
+    return array(
+      'node' => array(
+        'class' => 'EntityXliff\Drupal\Translatable\NodeTranslatable',
+      ),
+    );
+  }
+
+}

--- a/src/Drupal/Mediator/Entity.php
+++ b/src/Drupal/Mediator/Entity.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * @file
+ * Defines a mediator between the Drupal entity subsystem and the Entity XLIFF
+ * translatable system.
+ */
+
+namespace EntityXliff\Drupal\Mediator;
+
+use EntityXliff\Drupal\Utils\DrupalHandler;
+
+
+class Entity {
+
+  /**
+   * @var DrupalHandler
+   */
+  protected $drupal;
+
+  /**
+   * @var array
+   */
+  protected $classMap = array();
+
+  /**
+   * @param DrupalHandler $handler
+   *   (optional) An instance of the DrupalHandler class.
+   */
+  public function __construct(DrupalHandler $handler = NULL) {
+    // If no handler was provided, instantiate one ourselves.
+    if ($handler === NULL) {
+      $handler = new DrupalHandler();
+    }
+
+    $this->drupal = $handler;
+    $this->buildMap();
+  }
+
+  /**
+   * Builds an internal map of entity types to translatable classes.
+   */
+  public function buildMap() {
+    foreach ($this->drupal->entityGetInfo() as $type => $definition) {
+      if (isset($definition['entity xliff translatable class'])) {
+        $this->classMap[$type] = $definition['entity xliff translatable class'];
+      }
+    }
+  }
+
+  /**
+   * Given an Entity wrapper, returns its corresponding Translatable.
+   *
+   * @param \EntityDrupalWrapper $wrapper
+   *   The Entity wrapper for which a translatable is desired.
+   *
+   * @return \EggsCereal\Interfaces\TranslatableInterface|null
+   *   Returns an instance of the entity's translatable. If no translatable
+   *   class is known, NULL is returned.
+   */
+  public function getTranslatable(\EntityDrupalWrapper $wrapper) {
+    if ($translatable = $this->getTranslatableClass($wrapper)) {
+      return new $translatable($wrapper);
+    }
+    else {
+      return NULL;
+    }
+  }
+
+  /**
+   * Returns whether or not a given Entity can be translated (more specifically,
+   * whether or not an \EggsCereal\Interfaces\TranslatableInterface compatible
+   * translatable is known for the given entity type.
+   *
+   * @param \EntityDrupalWrapper $wrapper
+   *   The Entity wrapper for which translatability status is desired.
+   *
+   * @return bool
+   *   TRUE if the given Entity can be translated
+   */
+  public function canBeTranslated(\EntityDrupalWrapper $wrapper) {
+    return isset($this->classMap[$wrapper->type()]);
+  }
+
+  /**
+   * Returns the class for a given Entity wrapper's corresponding translatable.
+   *
+   * @param \EntityDrupalWrapper $wrapper
+   *   The Entity wrapper for which a translatable class is desired.
+   *
+   * @return string|bool
+   *   The name of the class (suitable for dynamic class instantiation) or FALSE
+   *   if the entity type is not known to be translatable.
+   */
+  public function getTranslatableClass(\EntityDrupalWrapper $wrapper) {
+    if ($this->canBeTranslated($wrapper)) {
+      return $this->classMap[$wrapper->type()];
+    }
+    else {
+      return FALSE;
+    }
+  }
+
+}

--- a/src/Drupal/Mediator/EntityMediator.php
+++ b/src/Drupal/Mediator/EntityMediator.php
@@ -11,7 +11,7 @@ namespace EntityXliff\Drupal\Mediator;
 use EntityXliff\Drupal\Utils\DrupalHandler;
 
 
-class Entity {
+class EntityMediator {
 
   /**
    * @var DrupalHandler

--- a/src/Drupal/Translatable/EntityTranslatableBase.php
+++ b/src/Drupal/Translatable/EntityTranslatableBase.php
@@ -9,7 +9,7 @@ namespace EntityXliff\Drupal\Translatable;
 
 use EggsCereal\Interfaces\TranslatableInterface;
 use EggsCereal\Utils\Data;
-use EntityXliff\Drupal\Mediator\Entity as EntityMediator;
+use EntityXliff\Drupal\Mediator\EntityMediator;
 use EntityXliff\Drupal\Utils\DrupalHandler;
 
 

--- a/src/Drupal/Translatable/EntityTranslatableBase.php
+++ b/src/Drupal/Translatable/EntityTranslatableBase.php
@@ -9,6 +9,7 @@ namespace EntityXliff\Drupal\Translatable;
 
 use EggsCereal\Interfaces\TranslatableInterface;
 use EggsCereal\Utils\Data;
+use EntityXliff\Drupal\Mediator\Entity as EntityMediator;
 use EntityXliff\Drupal\Utils\DrupalHandler;
 
 
@@ -31,6 +32,11 @@ abstract class EntityTranslatableBase implements TranslatableInterface  {
    * @var array
    */
   protected $entityInfo;
+
+  /**
+   * @var EntityMediator
+   */
+  protected $entityMediator;
 
   /**
    * @var \EntityDrupalWrapper[]
@@ -94,15 +100,6 @@ abstract class EntityTranslatableBase implements TranslatableInterface  {
   );
 
   /**
-   * Maps EntityTranslatable implementations to their entity names.
-   * @var array
-   */
-  protected $translatableMap = array(
-    'node' => 'EntityXliff\Drupal\Translatable\NodeTranslatable',
-    'field_collection_item' => 'EntityXliff\Drupal\Translatable\FieldCollectionTranslatable',
-  );
-
-  /**
    * Creates a Translatable from an Entity wrapper.
    *
    * @param \EntityDrupalWrapper $entityWrapper
@@ -111,23 +108,24 @@ abstract class EntityTranslatableBase implements TranslatableInterface  {
    * @param DrupalHandler $handler
    *   (Optional) Inject the utility Drupal handler.
    *
-   * @param array $entityInfo
-   *   (Optional) Inject entity info.
+   * @param EntityMediator $entityMediator
+   *   (Optional) Inject the entity mediator.
    */
-  public function __construct(\EntityDrupalWrapper $entityWrapper, DrupalHandler $handler = NULL, array $entityInfo = array()) {
+  public function __construct(\EntityDrupalWrapper $entityWrapper, DrupalHandler $handler = NULL, EntityMediator $entityMediator = NULL) {
     // If no Drupal Handler was provided, instantiate it manually.
     if ($handler === NULL) {
       $handler = new DrupalHandler();
     }
 
-    // If no entity info was provided, pull it manually.
-    if ($entityInfo === array()) {
-      $entityInfo = $handler->entityGetInfo();
+    // If no Entity mediator was provided, instantiate it manually.
+    if ($entityMediator === NULL) {
+      $entityMediator = new EntityMediator($handler);
     }
 
     $this->entity = $entityWrapper;
     $this->drupal = $handler;
-    $this->entityInfo = $entityInfo;
+    $this->entityMediator = $entityMediator;
+    $this->entityInfo = $handler->entityGetInfo();
   }
 
   /**
@@ -183,11 +181,13 @@ abstract class EntityTranslatableBase implements TranslatableInterface  {
 
     // Save any entities that need saving (this includes the target entity).
     foreach ($this->entitiesNeedSave as $key => $wrapper) {
-      $type = $wrapper->type();
+      $translatableClass = $this->entityMediator->getTranslatableClass($wrapper);
 
-      if (isset($this->translatableMap[$type]) && method_exists($this->translatableMap[$type], 'saveWrapper')) {
-        call_user_func_array($this->translatableMap[$type] . '::saveWrapper', array($wrapper));
+      // If a translatable class provides a static save method, call it.
+      if ($translatableClass && method_exists($translatableClass, 'saveWrapper')) {
+        call_user_func_array($translatableClass . '::saveWrapper', array($wrapper));
       }
+      // Otherwise, call \EntityDrupalWrapper::save().
       else {
         $wrapper->save();
       }
@@ -617,7 +617,7 @@ abstract class EntityTranslatableBase implements TranslatableInterface  {
   protected function entitySetReferencedEntity(\EntityDrupalWrapper $parent, $field, array $parents, $value, $targetLang) {
     $parentType = $parent->type();
     $needsSaveKey = $parent->type() . ':' . $parent->getIdentifier();
-    if (isset($this->translatableMap[$parentType])) {
+    if ($translatableClass = $this->entityMediator->getTranslatableClass($parent)) {
       // Load the translatable for this referenced entity.
       if (isset($this->entitiesNeedSave[$needsSaveKey])) {
         $parentWrapper = $this->entitiesNeedSave[$needsSaveKey];
@@ -631,7 +631,7 @@ abstract class EntityTranslatableBase implements TranslatableInterface  {
         $parentTranslatable = $this->translatables[$needsSaveKey];
       }
       else {
-        $parentTranslatable = new $this->translatableMap[$parentType]($parentWrapper);
+        $parentTranslatable = new $translatableClass($parentWrapper);
       }
 
       // Recreate the $data array for this referenced entity.

--- a/src/Drupal/Translatable/NodeTranslatable.php
+++ b/src/Drupal/Translatable/NodeTranslatable.php
@@ -7,7 +7,7 @@
 
 namespace EntityXliff\Drupal\Translatable;
 
-use EntityXliff\Drupal\Mediator\Entity as EntityMediator;
+use EntityXliff\Drupal\Mediator\EntityMediator;
 use EntityXliff\Drupal\Utils\DrupalHandler;
 
 

--- a/src/Drupal/Translatable/NodeTranslatable.php
+++ b/src/Drupal/Translatable/NodeTranslatable.php
@@ -7,6 +7,7 @@
 
 namespace EntityXliff\Drupal\Translatable;
 
+use EntityXliff\Drupal\Mediator\Entity as EntityMediator;
 use EntityXliff\Drupal\Utils\DrupalHandler;
 
 
@@ -27,8 +28,8 @@ class NodeTranslatable extends EntityTranslatableBase {
   /**
    * {@inheritdoc}
    */
-  public function __construct(\EntityDrupalWrapper $entityWrapper, DrupalHandler $handler = NULL) {
-    parent::__construct($entityWrapper, $handler);
+  public function __construct(\EntityDrupalWrapper $entityWrapper, DrupalHandler $handler = NULL, EntityMediator $entityMediator = NULL) {
+    parent::__construct($entityWrapper, $handler, $entityMediator);
 
     // Handle content translation for nodes.
     $this->drupal->staticReset('translation_node_get_translations');

--- a/src/Drupal/Translatable/NodeTranslatable.php
+++ b/src/Drupal/Translatable/NodeTranslatable.php
@@ -26,27 +26,21 @@ class NodeTranslatable extends EntityTranslatableBase {
 
   /**
    * {@inheritdoc}
-   *
-   * @param array $translationSet
-   *   An array of partial nodes, keyed by their respective language codes, that
-   *   constitute the translation set for this node. Used when content
-   *   translation is in use. If no translation set is provided, a default will
-   *   be provided by translation_node_get_translations().
    */
-  public function __construct(\EntityDrupalWrapper $entityWrapper, DrupalHandler $handler = NULL, array $entityInfo = array(), array $translationSet = array()) {
-    parent::__construct($entityWrapper, $handler, $entityInfo);
+  public function __construct(\EntityDrupalWrapper $entityWrapper, DrupalHandler $handler = NULL) {
+    parent::__construct($entityWrapper, $handler);
 
     // Handle content translation for nodes.
     $this->drupal->staticReset('translation_node_get_translations');
     if ($entityWrapper->language->value() === 'en') {
-      $this->tset = $translationSet ?: $this->nodeGetTranslations((int) $entityWrapper->getIdentifier());
+      $this->tset = $this->nodeGetTranslations((int) $entityWrapper->getIdentifier());
     }
     else {
       $raw = $entityWrapper->raw();
       if (!is_object($raw)) {
         $raw = $this->drupal->nodeLoad((int) $raw);
       }
-      $this->tset = $translationSet ?: $this->nodeGetTranslations((int) $raw->tnid);
+      $this->tset = $this->nodeGetTranslations((int) $raw->tnid);
     }
   }
 


### PR DESCRIPTION
API changes: removed unnecessary injection in translatable constructors, added the entity mediator as an injectable argument.

Sets up a hook system to declare translatable classes. Implements the hook on behalf of existing modules we support.
