### PR TITLE
Provide mechanism to determine translatability of wrapped entity

### DIFF
--- a/src/Drupal/Interfaces/EntityTranslatableInterface.php
+++ b/src/Drupal/Interfaces/EntityTranslatableInterface.php
@@ -40,6 +40,14 @@ interface EntityTranslatableInterface extends TranslatableInterface {
   public function getTranslatableFields();
 
   /**
+   * Returns whether or not the wrapped entity is translatable.
+   *
+   * @return bool
+   *   TRUE if the wrapped entity is translatable. FALSE otherwise.
+   */
+  public function isTranslatable();
+
+  /**
    * Saves a given Entity wrapper. This is the final step in saving translated
    * data on a given Entity; you may wish to override this static method in your
    * custom entity translatable implementation for special needs.

--- a/src/Drupal/Translatable/EntityTranslatableBase.php
+++ b/src/Drupal/Translatable/EntityTranslatableBase.php
@@ -169,12 +169,25 @@ abstract class EntityTranslatableBase implements EntityTranslatableInterface  {
   public function getTranslatableFields() {
     $fields = array();
 
+    // If the wrapped entity is not translatable, return no fields.
+    if (!$this->isTranslatable()) {
+      return $fields;
+    }
+
     foreach ($this->entity->getPropertyInfo() as $property => $info) {
       if (isset($info['field']) && $info['field']) {
         $fields[] = $property;
       }
     }
     return $fields;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isTranslatable() {
+    // @todo Assuming this needs one more check...
+    return $this->drupal->moduleExists('entity_translation');
   }
 
   /**

--- a/src/Drupal/Translatable/FieldCollectionTranslatable.php
+++ b/src/Drupal/Translatable/FieldCollectionTranslatable.php
@@ -22,7 +22,8 @@ class FieldCollectionTranslatable extends EntityTranslatableBase {
   public function getTargetEntity($targetLanguage) {
     if (!isset($this->targetEntities[$targetLanguage]) || empty($this->targetEntities[$targetLanguage])) {
       // Handling for content translation. Entity field translation should be
-      // taken care of by the parent.
+      // taken care of by the parent. @todo Need to be able to determine this
+      // based on the host entity's paradigm...
       if (!$this->drupal->moduleExists('entity_translation')) {
         $target = $this->getRawEntity($this->entity);
 

--- a/src/Drupal/Utils/DrupalHandler.php
+++ b/src/Drupal/Utils/DrupalHandler.php
@@ -141,6 +141,15 @@ class DrupalHandler {
   }
 
   /**
+   * Returns whether the given content type has support for translations.
+   * @param string $type
+   * @return bool
+   */
+  public function translationSupportedType($type) {
+    return translation_supported_type($type);
+  }
+
+  /**
    * Loads a user object.
    * @param int $uid
    * @param bool $reset


### PR DESCRIPTION
Adds `EntityTranslatableInterface::isTranslatable()`. Checks translatability before returning fields.
