### PR TITLE
Only save entities on data set operations

### DIFF
--- a/src/Drupal/Interfaces/EntityTranslatableInterface.php
+++ b/src/Drupal/Interfaces/EntityTranslatableInterface.php
@@ -48,6 +48,16 @@ interface EntityTranslatableInterface extends TranslatableInterface {
   public function isTranslatable();
 
   /**
+   * Takes the wrapped entity from a non-translated state to a ready-to-be
+   * translated state (or does nothing if it is already in the latter state).
+   *
+   * In most cases, this will update the wrapped entity's language from language
+   * neutral (und) to a specific language and perform any entity saves that it
+   * needs.
+   */
+  public function initializeTranslation();
+
+  /**
    * Saves a given Entity wrapper. This is the final step in saving translated
    * data on a given Entity; you may wish to override this method in your
    * custom entity translatable implementation for special needs.

--- a/src/Drupal/Translatable/EntityTranslatableBase.php
+++ b/src/Drupal/Translatable/EntityTranslatableBase.php
@@ -145,6 +145,9 @@ abstract class EntityTranslatableBase implements EntityTranslatableInterface  {
       return;
     }
 
+    // Attempt to initialize translation.
+    $this->initializeTranslation();
+
     // Save any entities that need saving (this includes the target entity).
     foreach ($this->entitiesNeedSave as $key => $wrapper) {
       $this->translatableFactory->getTranslatable($wrapper)->saveWrapper($wrapper);
@@ -188,6 +191,16 @@ abstract class EntityTranslatableBase implements EntityTranslatableInterface  {
   public function isTranslatable() {
     // @todo Assuming this needs one more check...
     return $this->drupal->moduleExists('entity_translation');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function initializeTranslation() {
+    if ($this->entity->language->value() === DrupalHandler::LANGUAGE_NONE) {
+      $this->entity->language->set('en');
+      $this->entity->save();
+    }
   }
 
   /**

--- a/src/Drupal/Translatable/FieldCollectionTranslatable.php
+++ b/src/Drupal/Translatable/FieldCollectionTranslatable.php
@@ -73,6 +73,15 @@ class FieldCollectionTranslatable extends EntityTranslatableBase {
   /**
    * {@inheritdoc}
    *
+   * This should never be called anyway since a Field Collection will always be
+   * saved in the context of a host entity. But just in case, this should be a
+   * no-op for this entity type.
+   */
+  public function initializeTranslation() {}
+
+  /**
+   * {@inheritdoc}
+   *
    * Do not save the host entity; that is taken care of elsewhere.
    */
   public function saveWrapper(\EntityDrupalWrapper $wrapper) {

--- a/src/Drupal/Translatable/NodeTranslatable.php
+++ b/src/Drupal/Translatable/NodeTranslatable.php
@@ -122,9 +122,6 @@ class NodeTranslatable extends EntityTranslatableBase {
         }
         // Otherwise, "clone" the original and mark it as new.
         else {
-          // Ensure that the original is ready for translation.
-          $this->initializeContentTranslation();
-
           $target = $this->getRawEntity($this->entity);
           $target->translation_source = clone $target;
 
@@ -145,13 +142,12 @@ class NodeTranslatable extends EntityTranslatableBase {
   }
 
   /**
-   * Initializes content translation on the translation set master, in cases
-   * where it hasn't yet been translated.
+   * {@inheritdoc}
    *
-   * Put in English: this converts a language neutral node to an English node
-   * that is part of a translation set.
+   * This converts a language neutral node to an English node that is part of a
+   * translation set.
    */
-  protected function initializeContentTranslation() {
+  public function initializeTranslation() {
     $nid = (int) $this->entity->getIdentifier();
     $source = $this->drupal->nodeLoad($nid, NULL, TRUE);
     if ($source->language === DrupalHandler::LANGUAGE_NONE || empty($source->tnid)) {


### PR DESCRIPTION
Adds `EntityTranslatableInterface::initializeTranslation()` and adjusts instance implementations according to its newly defined purpose.
