### PR TITLE
Minor version bump to Eggs'n'Cereal library version constraint.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "psr-4": {"EntityXliff\\": "src/"}
   },
   "require": {
-    "tableau-mkt/eggs-n-cereal": "0.0.1"
+    "tableau-mkt/eggs-n-cereal": "0.0.2"
   },
   "require-dev": {
     "phpunit/phpunit": "~4"


### PR DESCRIPTION
Bumps Eggs'n'Cereal dependency from v0.0.1 to v0.0.2.
