### PR TITLE
Fix entity metadata wrapper exceptions on integer fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,14 @@ php:
   - nightly
   - hhvm
 
+# Temporarily allow HHVM to fail.
+# @see https://github.com/travis-ci/travis-ci/issues/3790
+# @see https://github.com/facebook/hhvm/issues/5215
+#
+matrix:
+  allow_failures:
+    - php: hhvm
+
 before_script:
   - composer self-update
   - composer install --dev --prefer-source

--- a/modules/list.entity_xliff.inc
+++ b/modules/list.entity_xliff.inc
@@ -14,7 +14,7 @@ if (!function_exists('number_entity_xliff_field_handler_info')) {
   function number_entity_xliff_field_handler_info() {
     return array(
       'integer' => array(
-        'class' => 'EntityXliff\Drupal\FieldHandlers\DefaultFieldHandler',
+        'class' => 'EntityXliff\Drupal\FieldHandlers\IntegerFieldHandler',
       ),
     );
   }

--- a/src/Drupal/FieldHandlers/IntegerFieldHandler.php
+++ b/src/Drupal/FieldHandlers/IntegerFieldHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @file
+ * Defines an entity xliff field handler for integers, used because the Entity
+ * API performs very strict type validation on values.
+ */
+
+namespace EntityXliff\Drupal\FieldHandlers;
+
+use EntityXliff\Drupal\Interfaces\FieldHandlerInterface;
+
+
+class IntegerFieldHandler implements FieldHandlerInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValue(\EntityMetadataWrapper $wrapper) {
+    return $wrapper->value();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setValue(\EntityMetadataWrapper $wrapper, $value) {
+    $wrapper->set(intval($value));
+  }
+
+}

--- a/test/Drupal/FieldHandlers/IntegerFieldHandlerTest.php
+++ b/test/Drupal/FieldHandlers/IntegerFieldHandlerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace EntityXliff\Drupal\Tests\FieldHandlers;
+
+
+use EntityXliff\Drupal\FieldHandlers\IntegerFieldHandler;
+
+class IntegerFieldHandlerTest extends \PHPUnit_Framework_TestCase {
+
+  /**
+   * Tests that the default field handler merely returns $wrapper->value().
+   *
+   * @test
+   */
+  public function getValue() {
+    $expectedResponse = 'value';
+
+    $observerWrapper = $this->getMock('\EntityMetadataWrapper', array('value'));
+    $observerWrapper->expects($this->once())
+      ->method('value')
+      ->willReturn($expectedResponse);
+
+    $handler = new IntegerFieldHandler();
+    $this->assertEquals($expectedResponse, $handler->getValue($observerWrapper));
+  }
+
+  /**
+   * Tests that the integer field handler calls $wrapper->set() with the intval
+   * of the given value.
+   *
+   * @test
+   */
+  public function setValue() {
+    $mockValue = '123';
+    $expectedValue = intval($mockValue);
+
+    $observerWrapper = $this->getMock('\EntityMetadataWrapper', array('set'));
+    $observerWrapper->expects($this->once())
+      ->method('set')
+      ->with($this->identicalTo($expectedValue));
+
+    $handler = new IntegerFieldHandler();
+    $handler->setValue($observerWrapper, $mockValue);
+  }
+
+}


### PR DESCRIPTION
Fixes.`EntityMetadataWrapper Exception: Invalid data value given. Be sure it matches the required data type and format. in EntityMetadataWrapper->set()` on integer fields.
