### PR TITLE
Add the ability to alter translatable fields

### DIFF
--- a/entity_xliff.module
+++ b/entity_xliff.module
@@ -120,10 +120,17 @@ function entity_xliff_get_field_handlers() {
  * Loads in includes provided on behalf of existing modules.
  */
 function _entity_xliff_load_module_incs() {
-  // This potentially runs before hook_init(), so register auto-loader now.
-  composer_manager_register_autoloader();
-  foreach (array('node', 'user', 'taxonomy', 'comment', 'field_collection', 'link', 'image', 'text', 'number', 'list') as $entity) {
-    module_load_include('inc', 'entity_xliff', 'modules/' . $entity . '.entity_xliff');
+  static $loaded = FALSE;
+
+  // This may be called many times per request. Reduce overhead w/static flag.
+  if (!$loaded) {
+    // This potentially runs before hook_init(), so register auto-loader now.
+    composer_manager_register_autoloader();
+    foreach (array('node', 'user', 'taxonomy', 'comment', 'field_collection', 'link', 'image', 'text', 'number', 'list', 'auto_nodetitle', 'auto_entitylabel') as $entity) {
+      module_load_include('inc', 'entity_xliff', 'modules/' . $entity . '.entity_xliff');
+    }
+
+    $loaded = TRUE;
   }
 }
 

--- a/modules/auto_entitylabel.entity_xliff.inc
+++ b/modules/auto_entitylabel.entity_xliff.inc
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file
+ * Hooks implemented on behalf of the Automatic Entity Label module to integrate
+ * with Entity Xliff.
+ */
+
+
+if (!function_exists('auto_entitylabel_entity_xliff_translatable_fields_alter')) {
+
+  /**
+   * Implements hook_entity_xliff_translatable_fields_alter().
+   */
+  function auto_entitylabel_entity_xliff_translatable_fields_alter(&$fields, $wrapper) {
+    // If this entity/bundle combo has Automatic Entity Labeling enabled...
+    $ael_key = $wrapper->type() . '_' . $wrapper->getBundle();
+    if (auto_entitylabel_get_setting($ael_key) == AUTO_ENTITYLABEL_ENABLED) {
+      // Do not allow the label to be translatable.
+      $key = array_search($wrapper->entityKey('label'), $fields);
+      if ($key !== FALSE) {
+        unset($fields[$key]);
+      }
+    }
+  }
+
+}

--- a/modules/auto_nodetitle.entity_xliff.inc
+++ b/modules/auto_nodetitle.entity_xliff.inc
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @file
+ * Hooks implemented on behalf of the Automatic Nodetitles module to integrate
+ * with Entity Xliff.
+ */
+
+
+if (!function_exists('auto_nodetitle_entity_xliff_translatable_fields_alter')) {
+
+  /**
+   * Implements hook_entity_xliff_translatable_fields_alter().
+   */
+  function auto_nodetitle_entity_xliff_translatable_fields_alter(&$fields, $wrapper) {
+    // If this is a node and automatic node titles is enabled...
+    if ($wrapper->type() === 'node' && auto_nodetitle_get_setting($wrapper->getBundle()) == AUTO_NODETITLE_ENABLED) {
+      // Do not allow the title to be translatable.
+      $key = array_search('title', $fields);
+      if ($key !== FALSE) {
+        unset($fields[$key]);
+      }
+    }
+  }
+
+}

--- a/src/Drupal/Translatable/EntityTranslatableBase.php
+++ b/src/Drupal/Translatable/EntityTranslatableBase.php
@@ -121,6 +121,10 @@ abstract class EntityTranslatableBase implements EntityTranslatableInterface  {
     $data = array();
     $fields = $this->getTranslatableFields();
 
+    // Allow modules to alter translatable fields for this entity.
+    $this->drupal->entityXliffLoadModuleIncs();
+    $this->drupal->alter('entity_xliff_translatable_fields', $fields, $this->entity);
+
     // Iterate through all fields we're expecting to translate.
     foreach ($fields as $field) {
       if ($fieldData = $this->getFieldFromEntity($this->entity, $field)) {

--- a/src/Drupal/Utils/DrupalHandler.php
+++ b/src/Drupal/Utils/DrupalHandler.php
@@ -115,6 +115,13 @@ class DrupalHandler {
   }
 
   /**
+   * Loads in includes provided on behalf of existing modules.
+   */
+  public function entityXliffLoadModuleIncs() {
+    _entity_xliff_load_module_incs();
+  }
+
+  /**
    * Determines whether a given module exists.
    * @param string $module
    * @return bool

--- a/test/Drupal/Translatable/EntityTranslatableBaseTest.php
+++ b/test/Drupal/Translatable/EntityTranslatableBaseTest.php
@@ -52,7 +52,20 @@ namespace EntityXliff\Drupal\Tests\Translatable {
      */
     public function getData() {
       $mockEntity = $this->getMockWrapper();
-      $translatable = new EntityTranslatableMockForGetData($mockEntity);
+      $mockMediator = $this->getMockMediator();
+      $listenerDrupal = $this->getMockHandler();
+
+      // Instantiate the translatable.
+      $translatable = new EntityTranslatableMockForGetData($mockEntity, $listenerDrupal, NULL, $mockMediator);
+
+      // Ensure translatable fields are alterable, with the entity (as context).
+      $listenerDrupal->expects($this->once())
+        ->method('entityXliffLoadModuleIncs');
+      $listenerDrupal->expects($this->once())
+        ->method('alter')
+        ->with('entity_xliff_translatable_fields', array_keys($translatable->translatableFieldData), $mockEntity);
+
+      // Ensure the translatable data returned matches expectations.
       $this->assertSame($translatable->translatableFieldData, $translatable->getData());
       $this->assertSame($translatable->gotFieldFromEntity, $mockEntity);
     }


### PR DESCRIPTION
Introduces a new alter hook: `hook_entity_xliff_translatable_fields_alter()`, with the following signature:

``` php
/**
 * Alter translatable fields for a given entity. Useful for removing or adding
 * entity fields and properties to the generated XLIFF.
 *
 * @param array $fields
 *   An array of field or property names that represent translatable data.
 *   Note: the array keys are meaningless and can change at any time,
 *   You may need to use array_search() to find a specific value.
 *
 * @param \EntityDrupalwrapper $wrapper
 *   An entity metadata wrapper for the entity in question, useful for
 *   context.  For examplee, you may wish to conditionally alter
 *   translatable fields by entity type via $wrapper->type() or entity bundle
 *   via $wrapper->getBundle().
 */
function hook_entity_xliff_translatable_fields_alter(&$fields, $wrapper) {
  if ($wrapper->type() === 'my_entity_type') {
    $key = array_search('my_untranslatable_field', $fields);
    if ($key !== FALSE) {
      unset($fields[$key]);
    }
  }
}
```

Also implements this hook on behalf of the Automatic Nodetitles module and the Automatic Entity Labels modules.
