### PR TITLE
Universal way to get a Serializer

### DIFF
--- a/entity_xliff.admin.inc
+++ b/entity_xliff.admin.inc
@@ -6,8 +6,6 @@
  */
 
 
-use EggsCereal\Serializer;
-
 /**
  * Page callback (as a form) which provides an extremely basic UI around
  * exporting and importing entities via XLIFF. The UI should never, ever be
@@ -100,7 +98,7 @@ function entity_xliff_actions_submit($form, &$form_state) {
     $entity = $form_state['build_info']['args'][1];
     $wrapper = entity_metadata_wrapper($type, $entity);
     $translatable = entity_xliff_get_translatable($wrapper);
-    $serializer = new Serializer();
+    $serializer = entity_xliff_get_serializer('en');
 
     foreach ($form_state['storage']['import'] as $langcode => $file) {
       $xliff = file_get_contents($file->uri);

--- a/entity_xliff.module
+++ b/entity_xliff.module
@@ -5,6 +5,7 @@
  * Module hooks and functions for the Entity XLIFF module.
  */
 
+use EggsCereal\Serializer;
 use EntityXliff\Drupal\Factories\EntityTranslatableFactory;
 
 /**
@@ -100,6 +101,27 @@ function entity_xliff_entity_info_alter(&$entityInfo) {
  */
 function entity_xliff_get_translatable($wrapper) {
   return EntityTranslatableFactory::getInstance()->getTranslatable($wrapper);
+}
+
+/**
+ * Gets an EggsCereal\Serializer instance, set up to serialize and unserialize
+ * data with the provided source language.
+ *
+ * @param string $sourceLanguage
+ *   Language code representing the source language for documents to be either
+ *   serialized or validated during unserialization.
+ *
+ * @return Serializer
+ *   A configured instance of an XLIFF serializer.
+ */
+function entity_xliff_get_serializer($sourceLanguage) {
+  $serializer = new Serializer($sourceLanguage);
+  if (module_exists('psr3_watchdog')) {
+    composer_manager_register_autoloader();
+    $logger = new Psr3Watchdog();
+    $serializer->setLogger($logger);
+  }
+  return $serializer;
 }
 
 /**

--- a/entity_xliff.pages.inc
+++ b/entity_xliff.pages.inc
@@ -5,7 +5,6 @@
  * Functions that handle UI-based use-cases...
  */
 
-use EggsCereal\Serializer;
 
 /**
  * @see drupal_deliver_html_page()
@@ -42,7 +41,7 @@ function entity_xliff_deliver_xlf($page_callback_result) {
  *   serialized to XLIFF, the MENU_NOT_FOUND constant will be returned.
  */
 function entity_xliff_to_xlf($type, $entity) {
-  $serializer = new Serializer();
+  $serializer = entity_xliff_get_serializer('en');
   $wrapper = entity_metadata_wrapper($type, $entity);
   $targetlang = entity_xliff_get_target_lang();
 


### PR DESCRIPTION
Introduces `entity_xliff_get_serializer($sourceLanguage);`, and replaces all current manual instantiations of `EggsCereal\Serializer()`.

Couple of advantages:
- Creates a stable API for integration modules to get a serializer without having to know the details of `EggsCereal\Serializer`.
- Gives us a stable place to set (and alter) a translatable's source language _and_ the serializer's source language. Parity here is required due to the serializer's import validation mechanism checking the source language.
- Also adds support for logging serialization events to watchdog via PSR3 Watchdog module.
