### PR TITLE
Allow non-English content to be the source for translation

### DIFF
--- a/entity_xliff.admin.inc
+++ b/entity_xliff.admin.inc
@@ -98,9 +98,10 @@ function entity_xliff_actions_submit($form, &$form_state) {
     $entity = $form_state['build_info']['args'][1];
     $wrapper = entity_metadata_wrapper($type, $entity);
     $translatable = entity_xliff_get_translatable($wrapper);
-    $serializer = entity_xliff_get_serializer('en');
 
     foreach ($form_state['storage']['import'] as $langcode => $file) {
+      $sourceLang = $translatable->getSourceLanguage();
+      $serializer = entity_xliff_get_serializer($sourceLang);
       $xliff = file_get_contents($file->uri);
       $data = $serializer->unserialize($translatable, $langcode, $xliff);
 

--- a/entity_xliff.module
+++ b/entity_xliff.module
@@ -115,9 +115,9 @@ function entity_xliff_get_translatable($wrapper) {
  *   A configured instance of an XLIFF serializer.
  */
 function entity_xliff_get_serializer($sourceLanguage) {
+  composer_manager_register_autoloader();
   $serializer = new Serializer($sourceLanguage);
   if (module_exists('psr3_watchdog')) {
-    composer_manager_register_autoloader();
     $logger = new Psr3Watchdog();
     $serializer->setLogger($logger);
   }

--- a/entity_xliff.pages.inc
+++ b/entity_xliff.pages.inc
@@ -41,11 +41,12 @@ function entity_xliff_deliver_xlf($page_callback_result) {
  *   serialized to XLIFF, the MENU_NOT_FOUND constant will be returned.
  */
 function entity_xliff_to_xlf($type, $entity) {
-  $serializer = entity_xliff_get_serializer('en');
   $wrapper = entity_metadata_wrapper($type, $entity);
   $targetlang = entity_xliff_get_target_lang();
 
   if ($translatable = entity_xliff_get_translatable($wrapper)) {
+    $sourceLang = $translatable->getSourceLanguage();
+    $serializer = entity_xliff_get_serializer($sourceLang);
     entity_xliff_file_name(implode('-', array($type, $wrapper->getIdentifier(), $targetlang)) . '.xlf');
     return $serializer->serialize($translatable, $targetlang);
   }

--- a/src/Drupal/Interfaces/EntityTranslatableInterface.php
+++ b/src/Drupal/Interfaces/EntityTranslatableInterface.php
@@ -13,6 +13,14 @@ use EggsCereal\Interfaces\TranslatableInterface;
 interface EntityTranslatableInterface extends TranslatableInterface {
 
   /**
+   * Returns the language of the wrapped entity, in effect representing the
+   * "source" language for any XLIFF generated or being processed.
+   *
+   * @return string
+   */
+  public function getSourceLanguage();
+
+  /**
    * Returns the target entity used by TranslatableInterface::setData() to set
    * and save translated data for this entity.
    *

--- a/src/Drupal/Translatable/Content/NodeTranslatable.php
+++ b/src/Drupal/Translatable/Content/NodeTranslatable.php
@@ -34,11 +34,11 @@ class NodeTranslatable extends EntityTranslatableBase {
     parent::__construct($entityWrapper, $handler, $factory, $fieldMediator);
 
     $this->drupal->staticReset('translation_node_get_translations');
-    if ($entityWrapper->language->value() === 'en') {
+    $raw = $entityWrapper->raw();
+    if (!isset($raw->tnid) || empty($raw->tnid)) {
       $this->tset = $this->nodeGetTranslations((int) $entityWrapper->getIdentifier());
     }
     else {
-      $raw = $this->getRawEntity($entityWrapper);
       $this->tset = $this->nodeGetTranslations((int) $raw->tnid);
     }
   }
@@ -102,7 +102,7 @@ class NodeTranslatable extends EntityTranslatableBase {
     $source = $this->drupal->nodeLoad($nid, NULL, TRUE);
     if ($source->language === DrupalHandler::LANGUAGE_NONE || empty($source->tnid)) {
       $source->tnid = $nid;
-      $source->language = 'en';
+      $source->language = $this->getSourceLanguage();
       $this->drupal->nodeSave($source);
       $this->entity = $this->drupal->entityMetadataWrapper('node', $source);
       $this->drupal->staticReset('translation_node_get_translations');

--- a/src/Drupal/Translatable/EntityFieldTranslatableBase.php
+++ b/src/Drupal/Translatable/EntityFieldTranslatableBase.php
@@ -18,6 +18,16 @@ abstract class EntityFieldTranslatableBase extends EntityTranslatableBase {
   /**
    * {@inheritdoc}
    */
+  public function getSourceLanguage() {
+    $rawEntity = $this->entity->raw();
+    $type = $this->entity->type();
+    $handler = $this->drupal->entityTranslationGetHandler($type, $rawEntity);
+    return $handler->getLanguage();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getTranslatableFields() {
     $fields = array();
 
@@ -49,7 +59,7 @@ abstract class EntityFieldTranslatableBase extends EntityTranslatableBase {
   public function getTargetEntity($targetLanguage) {
     if (!isset($this->targetEntities[$targetLanguage]) || empty($this->targetEntities[$targetLanguage])) {
       $target = clone $this->entity;
-      $target->language->set('en');
+      $target->language->set($this->getSourceLanguage());
       $target->language($targetLanguage);
       $this->targetEntities[$targetLanguage] = $target;
     }
@@ -61,13 +71,14 @@ abstract class EntityFieldTranslatableBase extends EntityTranslatableBase {
    */
   public function initializeTranslation() {
     if ($this->entity->language->value() === DrupalHandler::LANGUAGE_NONE) {
-      $this->entity->language('en');
+      $sourceLanguage = $this->getSourceLanguage();
+      $this->entity->language($sourceLanguage);
       $rawEntity = $this->getRawEntity($this->entity);
       $type = $this->entity->type();
 
       // Initialize translation for this entity.
       $handler = $this->drupal->entityTranslationGetHandler($type, $rawEntity);
-      $handler->setOriginalLanguage('en');
+      $handler->setOriginalLanguage($sourceLanguage);
       $handler->initOriginalTranslation();
       $handler->saveTranslations();
 
@@ -95,7 +106,7 @@ abstract class EntityFieldTranslatableBase extends EntityTranslatableBase {
       'status' => TRUE,
       'language' => $targetLanguage,
       // @see EntityFieldTranslatableBase::initializeTranslation()
-      'source' => 'en',
+      'source' => $this->getSourceLanguage(),
     ));
     $handler->saveTranslations();
   }

--- a/src/Drupal/Translatable/EntityTranslatableBase.php
+++ b/src/Drupal/Translatable/EntityTranslatableBase.php
@@ -117,6 +117,17 @@ abstract class EntityTranslatableBase implements EntityTranslatableInterface  {
   /**
    * {@inheritdoc}
    */
+  public function getSourceLanguage() {
+    $language = $this->entity->language->value();
+    if ($language === DrupalHandler::LANGUAGE_NONE || empty($language)) {
+      $language = $this->drupal->languageDefault('language');
+    }
+    return $language;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getData() {
     $data = array();
     $fields = $this->getTranslatableFields();

--- a/src/Drupal/Utils/DrupalHandler.php
+++ b/src/Drupal/Utils/DrupalHandler.php
@@ -122,6 +122,15 @@ class DrupalHandler {
   }
 
   /**
+   * Returns the default language used on the site
+   * @param string $property
+   * @return mixed
+   */
+  public function languageDefault($property = NULL) {
+    return language_default($property);
+  }
+
+  /**
    * Determines whether a given module exists.
    * @param string $module
    * @return bool

--- a/test/Drupal/Translatable/Content/NodeTranslatableTest.php
+++ b/test/Drupal/Translatable/Content/NodeTranslatableTest.php
@@ -24,21 +24,21 @@ class NodeTranslatableTest extends \PHPUnit_Framework_TestCase {
 
   /**
    * Tests that constructor will pull the translation set for the wrapped entity
-   * as expected, specifically in the case that the wrapped entity is English.
+   * as expected, specifically in the case that the wrapped entity represents an
+   * as-yet untranslated node.
    *
    * @test
    */
-  public function constructTranslatableFromEnglish() {
+  public function constructTranslatableAsYetUntranslated() {
     $expectedNid = 123;
 
-    $observerWrapper = $this->getMock('\EntityDrupalWrapper', array('getIdentifier'));
+    $observerWrapper = $this->getMock('\EntityDrupalWrapper', array('getIdentifier', 'raw'));
     $observerWrapper->expects($this->once())
       ->method('getIdentifier')
       ->willReturn((string) $expectedNid);
-    $observerWrapper->language = $this->getMock('\EntityMetadataWrapper', array('value'));
-    $observerWrapper->language->expects($this->once())
-      ->method('value')
-      ->willReturn('en');
+    $observerWrapper->expects($this->once())
+      ->method('raw')
+      ->willReturn((object) array());
 
     $observerDrupal = $this->getMockHandlerForConstructor($expectedNid);
 
@@ -52,21 +52,20 @@ class NodeTranslatableTest extends \PHPUnit_Framework_TestCase {
   /**
    * Tests that the constructor will pull the translation set from the wrapped
    * entity's translation source ID in the case that the wrapped entity is
-   * not English.
+   * already translated, and therefore already part of a translation set.
    *
    * @test
    */
-  public function constructTranslatableFromNonEnglish() {
+  public function constructTranslatableAlreadyTranslated() {
     $expectedNid = 123;
     $expectedRawNode = (object) array(
       'tnid' => $expectedNid,
     );
 
-    $observerWrapper = $this->getMock('\EntityDrupalWrapper');
-    $observerWrapper->language = $this->getMock('\EntityMetadataWrapper', array('value'));
-    $observerWrapper->language->expects($this->once())
-      ->method('value')
-      ->willReturn('de');
+    $observerWrapper = $this->getMock('\EntityDrupalWrapper', array('raw'));
+    $observerWrapper->expects($this->once())
+      ->method('raw')
+      ->willReturn($expectedRawNode);
 
     $observerDrupal = $this->getMockHandlerForConstructor($expectedNid);
 
@@ -240,6 +239,10 @@ class NodeTranslatableTest extends \PHPUnit_Framework_TestCase {
     $observerWrapper->expects($this->once())
       ->method('getIdentifier')
       ->willReturn((string) $expectedNid);
+    $observerWrapper->language = $this->getMock('\EntityMetadataWrapper', array('value'));
+    $observerWrapper->language->expects($this->once())
+      ->method('value')
+      ->willReturn('en');
 
     $observerDrupal = $this->getMock('EntityXliff\Drupal\Utils\DrupalHandler', array(
       'nodeLoad',
@@ -315,7 +318,7 @@ class MockNodeTranslatable extends NodeTranslatable {
    * @param \EntityDrupalWrapper $wrapper
    * @param DrupalHandler $handler
    */
-  public function __construct(\EntityDrupalWrapper$wrapper = NULL, DrupalHandler$handler = NULL) {
+  public function __construct(\EntityDrupalWrapper $wrapper = NULL, DrupalHandler$handler = NULL) {
     $this->entity = $wrapper;
     $this->drupal = $handler;
   }

--- a/test/Drupal/Translatable/EntityFieldTranslatableBaseTest.php
+++ b/test/Drupal/Translatable/EntityFieldTranslatableBaseTest.php
@@ -9,6 +9,40 @@ use EntityXliff\Drupal\Utils\DrupalHandler;
 class EntityFieldTranslatableBaseTest extends \PHPUnit_Framework_TestCase {
 
   /**
+   * Tests that EntityFieldTranslatableBase::getSourceLanguage() returns the
+   * language code of the wrapped entity as expected.
+   *
+   * @test
+   */
+  public function getSourceLanguage() {
+    $mockEntityType = 'node';
+    $mockEntityRaw = (object) array('nid' => 123);
+    $expectedLanguage = 'fr';
+
+    $observerWrapper = $this->getMock('\EntityDrupalWrapper', array('raw', 'type'));
+    $observerWrapper->expects($this->once())
+      ->method('raw')
+      ->willReturn($mockEntityRaw);
+    $observerWrapper->expects($this->once())
+      ->method('type')
+      ->willReturn($mockEntityType);
+
+    $observerHandler = $this->getMock('\EntityTranslationHandlerInterface', array('getLanguage'));
+    $observerHandler->expects($this->once())
+      ->method('getLanguage')
+      ->willReturn($expectedLanguage);
+
+    $observerDrupal = $this->getMockHandler();
+    $observerDrupal->expects($this->once())
+      ->method('entityTranslationGetHandler')
+      ->with($this->equalTo($mockEntityType), $this->equalTo($mockEntityRaw))
+      ->willReturn($observerHandler);
+
+    $translatable = new EntityFieldTranslatableBaseInstance($observerWrapper, $observerDrupal, NULL, $this->getMockMediator());
+    $this->assertSame($expectedLanguage, $translatable->getSourceLanguage());
+  }
+
+  /**
    * Tests that EntityFieldTranslatableBase::getTranslatableFields returns an
    * empty array when the wrapped entity is not translatable.
    *

--- a/test/Drupal/Translatable/EntityTranslatableBaseTest.php
+++ b/test/Drupal/Translatable/EntityTranslatableBaseTest.php
@@ -45,6 +45,47 @@ namespace EntityXliff\Drupal\Tests\Translatable {
     }
 
     /**
+     * Tests that EntityTranslatableBase::getSourceLanguage() returns the lang
+     * code of the wrapped entity, as expected.
+     *
+     * @test
+     */
+    public function getSourceLanguageReal() {
+      $expectedLanguage = 'fr';
+
+      $observerWrapper = $this->getMock('\EntityDrupalWrapper');
+      $observerWrapper->language = $this->getMock('\EntityMetadataWrapper', array('value'));
+      $observerWrapper->language->expects($this->once())
+        ->method('value')
+        ->willReturn($expectedLanguage);
+
+      $translatable = $this->getTranslatableOrNotInstance(TRUE, $observerWrapper);
+      $this->assertSame($expectedLanguage, $translatable->getSourceLanguage());
+    }
+
+    /**
+     * @test
+     */
+    public function getSourceLanguageNeutral() {
+      $expectedLanguage = 'en';
+
+      $observerDrupal = $this->getMockHandler();
+      $observerDrupal->expects($this->once())
+        ->method('languageDefault')
+        ->with($this->equalTo('language'))
+        ->willReturn($expectedLanguage);
+
+      $observerWrapper = $this->getMock('\EntityDrupalWrapper');
+      $observerWrapper->language = $this->getMock('\EntityMetadataWrapper', array('value'));
+      $observerWrapper->language->expects($this->once())
+        ->method('value')
+        ->willReturn(DrupalHandler::LANGUAGE_NONE);
+
+      $translatable = $this->getTranslatableOrNotInstance(TRUE, $observerWrapper, $observerDrupal);
+      $this->assertSame($expectedLanguage, $translatable->getSourceLanguage());
+    }
+
+    /**
      * Ensures that EntityTranslatableBase::getData() returns translatable data
      * as expected.
      *

--- a/test/Features/AlternateSourceLanguage.feature
+++ b/test/Features/AlternateSourceLanguage.feature
@@ -1,0 +1,32 @@
+@api
+Feature: Alternative Source Languages
+  In order to prove that source content can be of any language
+  Site administrators should be able to
+  Import and export XLIFF translations with language sources other than English
+
+  Background:
+    Given I am logged in as a user with the "administer entity xliff" permission
+    And "page" content:
+      | title             | body                   | language | promote |
+      | French page title | French page body text. | fr       | 1       |
+    And I am on the homepage
+    And I follow "French page title"
+
+  Scenario: Access and Export French sourced XLIFF through portal
+    When I click "XLIFF"
+    Then the url should match "node/\d+/xliff"
+    And I should see "Export as XLIFF"
+    And I should see "Import from XLIFF"
+    When I click "Download"
+    Then the response should contain "<xliff"
+    And the response should contain "<source xml:lang=\"fr\">French page title</source>"
+
+  Scenario: Import French sourced XLIFF through portal
+    When I click "XLIFF"
+    When I attach an "en" translation of this "French" node
+    And I press the "Import" button
+    Then I should see the success message containing "Successfully imported"
+    When I click "View"
+    And I click "English"
+    Then I should see the heading "en page title"
+    And I should see "en page body text."

--- a/test/Features/Bootstrap/FeatureContext.php
+++ b/test/Features/Bootstrap/FeatureContext.php
@@ -32,9 +32,9 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
   }
 
   /**
-   * @When I attach a :langcode translation of this :entity
+   * @When I attach a(n) :targetlang translation of this :sourcelang :entity
    */
-  public function iAttachATranslationOfThisEntity($langcode, $entity) {
+  public function iAttachATranslationOfThisEntity($targetLang, $sourceLang, $entity) {
     $baseUrl = $this->getMinkParameter('base_url');
     $path = $this->getMinkParameter('files_path');
     $session = $this->getSession();
@@ -43,14 +43,14 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
 
     if (preg_match('/' . preg_quote($pathPart, '/') . '\/(\d+)/', $url, $matches)) {
       $id = $matches[1];
-      $randomFile = mt_rand(0, 10000) . '-' . $langcode . '.xlf';
+      $randomFile = mt_rand(0, 10000) . '-' . $targetLang . '.xlf';
 
       // Load the XLIFF file for this node.
-      $this->getSession()->visit($baseUrl . "/$pathPart/$id/as.xlf?targetLang=$langcode");
+      $this->getSession()->visit($baseUrl . "/$pathPart/$id/as.xlf?targetLang=$targetLang");
       $xliff = $session->getPage()->getContent();
 
       // "Translate" the file.
-      $translation = str_replace('English', $langcode, $xliff);
+      $translation = str_replace($sourceLang, $targetLang, $xliff);
       $fullPath = $path . DIRECTORY_SEPARATOR . $randomFile;
 
       // Write the file to the configured path.
@@ -58,7 +58,7 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
         // Go back and attach the file to the expected import field.
         $session->visit($baseUrl . "/$pathPart/$id/xliff");
         $page = $session->getPage();
-        $importFileField = $page->find('css', 'input[name="files[import-' . $langcode . ']"]');
+        $importFileField = $page->find('css', 'input[name="files[import-' . $targetLang . ']"]');
         $importFileField->attachFile($fullPath);
       }
       else {

--- a/test/Features/CommentEntityTranslation.feature
+++ b/test/Features/CommentEntityTranslation.feature
@@ -30,7 +30,7 @@ Feature: Entity Field Translation of Comment Entities
   Scenario: Import XLIFF through portal
     When I click "delete"
     And I click "XLIFF"
-    When I attach a "fr" translation of this comment
+    When I attach a "fr" translation of this "English" comment
     And I press the "Import" button
     Then I should see the success message containing "Successfully imported"
     When I click "View"

--- a/test/Features/NodeContentTranslation.feature
+++ b/test/Features/NodeContentTranslation.feature
@@ -29,7 +29,7 @@ Feature: Content Translation of Node and Field Collection Entities
     When I am on the homepage
     And follow "English page title"
     And I click "XLIFF"
-    When I attach a "fr" translation of this node
+    When I attach a "fr" translation of this "English" node
     And I press the "Import" button
     Then I should see the success message containing "Successfully imported"
     When I click "View"
@@ -40,7 +40,7 @@ Feature: Content Translation of Node and Field Collection Entities
   Scenario: Import complex XLIFF through portal
     Given I am viewing a 3 complex "page" content with the title "Complex English page title"
     When I click "XLIFF"
-    And I attach a "fr" translation of this node
+    And I attach a "fr" translation of this "English" node
     And I press the "Import" button
     Then I should see the success message containing "Successfully imported"
     When I click "View"

--- a/test/Features/NodeEntityTranslation.feature
+++ b/test/Features/NodeEntityTranslation.feature
@@ -36,7 +36,7 @@ Feature: Entity Field Translation of Nodes
     And follow "English article title"
     And I click "XLIFF"
     Given this "node" has an image attached with alt text "Image English alt text"
-    When I attach a "fr" translation of this node
+    When I attach a "fr" translation of this "English" node
     And I press the "Import" button
     Then I should see the success message containing "Successfully imported"
     When I click "View"

--- a/test/Features/TermEntityTranslation.feature
+++ b/test/Features/TermEntityTranslation.feature
@@ -28,7 +28,7 @@ Feature: Entity Field Translation of Taxonomy Term Entities
 
   Scenario: Import XLIFF through portal
     When  I click "XLIFF"
-    And I attach a "fr" translation of this taxonomy_term
+    And I attach a "fr" translation of this "English" taxonomy_term
     And I press the "Import" button
     Then I should see the success message containing "Successfully imported"
     When I click "View"

--- a/test/Features/UserEntityTranslation.feature
+++ b/test/Features/UserEntityTranslation.feature
@@ -39,7 +39,7 @@ Feature: Entity Field Translation of User Entities
     And I click "Joe User"
     Then I should see the link "English link title"
     And I click "XLIFF"
-    When I attach a "fr" translation of this user
+    When I attach a "fr" translation of this "English" user
     And I press the "Import" button
     Then I should see the success message containing "Successfully imported"
     When I click "View"


### PR DESCRIPTION
As of Eggs'n'Cereal v0.0.6, source language is configurable (not just `en`).

This PR removes all hard-coded references to `en` as the source language, allowing content of any language to act as source.

API addition: `EntityTranslatableInterface::getSourceLanguage()` was added.  Implementations were added for both Content and Entity Field base classes.
