### PR TITLE
Introduce a unified API for getting/setting XLIFFs

### DIFF
--- a/entity_xliff.admin.inc
+++ b/entity_xliff.admin.inc
@@ -97,13 +97,10 @@ function entity_xliff_actions_submit($form, &$form_state) {
     $type = $form_state['build_info']['args'][0];
     $entity = $form_state['build_info']['args'][1];
     $wrapper = entity_metadata_wrapper($type, $entity);
-    $translatable = entity_xliff_get_translatable($wrapper);
 
     foreach ($form_state['storage']['import'] as $langcode => $file) {
-      $sourceLang = $translatable->getSourceLanguage();
-      $serializer = entity_xliff_get_serializer($sourceLang);
       $xliff = file_get_contents($file->uri);
-      $data = $serializer->unserialize($translatable, $langcode, $xliff);
+      $data = entity_xliff_set_xliff($wrapper, $langcode, $xliff);
 
       // If no data was returned, the import was invalid.
       if ($data === array()) {

--- a/entity_xliff.module
+++ b/entity_xliff.module
@@ -8,6 +8,69 @@
 use EggsCereal\Serializer;
 use EntityXliff\Drupal\Factories\EntityTranslatableFactory;
 
+
+/**
+ * Takes an Entity API wrapped entity and returns XLIFF XML data that represents
+ * it. This data can be used by localization software, a TMS, or a text editor
+ * to edit translations of this entity.
+ *
+ * @param \EntityDrupalWrapper $wrapper
+ *   The entity metadata wrapper for which you want an XLIFF.
+ *
+ * @param string $targetLanguage
+ *   Target language you want the XLIFF to represent. Should be the Drupal
+ *   language code.
+ *
+ * @return string
+ *   XLIFF XML data representing the given entity. If the given entity isn't
+ *   translatable, an empty string is returned.
+ */
+function entity_xliff_get_xliff($wrapper, $targetLanguage) {
+  $xliff = '';
+
+  if ($translatable = entity_xliff_get_translatable($wrapper)) {
+    $serializer = entity_xliff_get_serializer($translatable->getSourceLanguage());
+    $xliff = $serializer->serialize($translatable, $targetLanguage);
+    drupal_alter('entity_xliff_get_xliff', $xliff, $wrapper, $targetLanguage);
+  }
+
+  return $xliff;
+}
+
+/**
+ * Takes XLIFF data representing an entity and creates the translation that it
+ * represents.
+ *
+ * @param \EntityDrupalWrapper $wrapper
+ *   The entity metadata wrapper of the entity for whose translation you're
+ *   importing.
+ *
+ * @param string $targetLanguage
+ *   Target language the XLIFF represents. Should be a Drupal language code.
+ *
+ * @param string $xliff
+ *   A string of the XLIFF XML.
+ *
+ * @param bool $save
+ *   (Optional) Whether or not to actually set and save the underlying data to
+ *   the database. Defaults to TRUE.
+ *
+ * @return array
+ *   An associative array representing the translation data. If the returned
+ *   array is empty, it means the XLIFF unserialization process failed.
+ */
+function entity_xliff_set_xliff($wrapper, $targetLanguage, $xliff, $save = TRUE) {
+  $data = array();
+
+  if ($translatable = entity_xliff_get_translatable($wrapper)) {
+    $serializer = entity_xliff_get_serializer($translatable->getSourceLanguage());
+    drupal_alter('entity_xliff_set_xliff', $xliff, $wrapper, $targetLanguage);
+    $data = $serializer->unserialize($translatable, $targetLanguage, $xliff, $save);
+  }
+
+  return $data;
+}
+
 /**
  * Implements hook_menu().
  */

--- a/entity_xliff.pages.inc
+++ b/entity_xliff.pages.inc
@@ -44,11 +44,9 @@ function entity_xliff_to_xlf($type, $entity) {
   $wrapper = entity_metadata_wrapper($type, $entity);
   $targetlang = entity_xliff_get_target_lang();
 
-  if ($translatable = entity_xliff_get_translatable($wrapper)) {
-    $sourceLang = $translatable->getSourceLanguage();
-    $serializer = entity_xliff_get_serializer($sourceLang);
+  if ($xliff = entity_xliff_get_xliff($wrapper, $targetlang)) {
     entity_xliff_file_name(implode('-', array($type, $wrapper->getIdentifier(), $targetlang)) . '.xlf');
-    return $serializer->serialize($translatable, $targetlang);
+    return $xliff;
   }
   else {
     return MENU_NOT_FOUND;

--- a/src/Drupal/Translatable/EntityFieldTranslatableBase.php
+++ b/src/Drupal/Translatable/EntityFieldTranslatableBase.php
@@ -22,7 +22,8 @@ abstract class EntityFieldTranslatableBase extends EntityTranslatableBase {
     $rawEntity = $this->entity->raw();
     $type = $this->entity->type();
     $handler = $this->drupal->entityTranslationGetHandler($type, $rawEntity);
-    return $handler->getLanguage();
+    $language = $handler->getLanguage();
+    return $language;
   }
 
   /**


### PR DESCRIPTION
Introducing `entity_xliff_get_xliff()` and `entity_xliff_set_xliff()`, which should be the primary mechanism by which other modules get and set XLIFF data.

Also introduces `hook_entity_xliff_get_xliff_alter()` and `hook_entity_xliff_set_xliff_alter()`, which provide a unified way to alter data coming into and going out of Drupal in the XLIFF format.
