### PR TITLE
Node prepare

### DIFF
--- a/src/Drupal/Translatable/Content/NodeTranslatable.php
+++ b/src/Drupal/Translatable/Content/NodeTranslatable.php
@@ -74,16 +74,13 @@ class NodeTranslatable extends EntityTranslatableBase {
         // cases where this node happens to reference a field collection...
         $target->revision = FALSE;
       }
-      // Otherwise, "clone" the original and mark it as new.
+      // Otherwise prepare the original for translation.
       else {
         $this->initializeTranslation();
         $target = $this->getRawEntity($this->entity);
-        $target->translation_source = clone $target;
-
         unset($target->nid, $target->vid);
         $target->is_new = TRUE;
-        $target->tnid = (int) $this->entity->getIdentifier();
-        $target->language = $targetLanguage;
+        $this->translationNodePrepare($target, $this->entity->getIdentifier(), $targetLanguage);
       }
 
       $this->targetEntities[$targetLanguage] = $this->drupal->entityMetadataWrapper('node', $target);
@@ -128,6 +125,24 @@ class NodeTranslatable extends EntityTranslatableBase {
     $GLOBALS['user'] = $tempUser;
     $this->drupal->saveSession(TRUE);
     return $tset;
+  }
+
+  /**
+   * OO wrapper around translation_node_prepare().
+   * @param object $node
+   * @param int $sourceNid
+   * @param string $targetLang
+   */
+  protected function translationNodePrepare($node, $sourceNid, $targetLang) {
+    $tempUser = clone $GLOBALS['user'];
+    $this->drupal->saveSession(FALSE);
+    $GLOBALS['user'] = $this->drupal->userLoad(1);
+    $_GET['translation'] = $sourceNid;
+    $_GET['target'] = $targetLang;
+    $this->drupal->translationNodePrepare($node);
+    unset($_GET['translation'], $_GET['target']);
+    $GLOBALS['user'] = $tempUser;
+    $this->drupal->saveSession(TRUE);
   }
 
 }

--- a/src/Drupal/Utils/DrupalHandler.php
+++ b/src/Drupal/Utils/DrupalHandler.php
@@ -199,6 +199,14 @@ class DrupalHandler {
   }
 
   /**
+   * Prepares a node for translation (content translation paradigm).
+   * @param object $node
+   */
+  public function translationNodePrepare($node) {
+    translation_node_prepare($node);
+  }
+
+  /**
    * Returns whether the given content type has support for translations.
    * @param string $type
    * @return bool

--- a/test/Drupal/Translatable/Content/NodeTranslatableTest.php
+++ b/test/Drupal/Translatable/Content/NodeTranslatableTest.php
@@ -187,12 +187,6 @@ class NodeTranslatableTest extends \PHPUnit_Framework_TestCase {
       'nid' => $targetNid,
       'vid' => 456,
     );
-    $expectedRawnode = (object) array(
-      'translation_source' => clone $willedRawNode,
-      'is_new' => TRUE,
-      'tnid' => $targetNid,
-      'language' => $targetLang,
-    );
     $expectedEntity = 'expected entity wrapper';
 
     $observerWrapper = $this->getMock('\EntityDrupalWrapper', array('getIdentifier'));
@@ -200,10 +194,10 @@ class NodeTranslatableTest extends \PHPUnit_Framework_TestCase {
       ->method('getIdentifier')
       ->willReturn($targetNid);
 
-    $observerDrupal = $this->getMock('EntityXliff\Drupal\Utils\DrupalHandler', array('entityMetadataWrapper', 'nodeLoad'));
+    $observerDrupal = $this->getMock('EntityXliff\Drupal\Utils\DrupalHandler', array('entityMetadataWrapper', 'nodeLoad', 'translationNodePrepare', 'saveSession', 'userLoad'));
     $observerDrupal->expects($this->once())
       ->method('entityMetadataWrapper')
-      ->with($this->equalTo('node'), $this->equalTo($expectedRawnode))
+      ->with($this->equalTo('node'))
       ->willReturn($expectedEntity);
     // Ensure translation initialization is triggered in this case.
     $observerDrupal->expects($this->atLeastOnce())
@@ -212,6 +206,10 @@ class NodeTranslatableTest extends \PHPUnit_Framework_TestCase {
         'language' => 'fr',
         'tnid' => 1,
       ));
+    // Ensure node translation preparation occurs.
+    $observerDrupal->expects($this->once())
+      ->method('translationNodePrepare')
+      ->with($this->equalTo($willedRawNode));
 
     $translatable = $this->getMockBuilder('EntityXliff\Drupal\Tests\Translatable\Content\MockNodeTranslatable')
       ->setMethods(array('getRawEntity'))


### PR DESCRIPTION
Ensures new node translations (using the content translation paradigms) go through the standard node preparation process.
