### PR TITLE
Preserve path alias when translating an existing node.

### DIFF
--- a/src/Drupal/Translatable/Content/NodeTranslatable.php
+++ b/src/Drupal/Translatable/Content/NodeTranslatable.php
@@ -91,6 +91,9 @@ class NodeTranslatable extends EntityTranslatableBase {
         $target->vid = $actual_target->vid;
         $target->tnid = $actual_target->tnid;
 
+        // Preserve the original target's path alias.
+        $target->path = $actual_target->path;
+
         // Do not mark this node as a new revision. This is necessary in
         // cases where this node happens to reference a field collection...
         $target->revision = FALSE;

--- a/test/Drupal/Translatable/Content/NodeTranslatableTest.php
+++ b/test/Drupal/Translatable/Content/NodeTranslatableTest.php
@@ -161,6 +161,12 @@ class NodeTranslatableTest extends \PHPUnit_Framework_TestCase {
       'nid' => $targetNid,
       'tnid' => $sourceNid,
       'vid' => 123,
+      'path' => array(
+        'pid' => 1,
+        'source' => 'node/' . $targetNid,
+        'alias' => 'willed-title',
+        'language' => $targetLang,
+      ),
     ));
     $expectedSourceNode = clone $sourceNode;
     $expectedTarget = new \stdClass(); //clone $sourceNode;


### PR DESCRIPTION
Follow-up to #89. Regression was introduced where an existing translation's path alias would be lost when re-translated.
