### PR TITLE
Fix source language mutation after content translation initialization

### DIFF
--- a/src/Drupal/Translatable/EntityTranslatableBase.php
+++ b/src/Drupal/Translatable/EntityTranslatableBase.php
@@ -64,6 +64,12 @@ abstract class EntityTranslatableBase implements EntityTranslatableInterface  {
   protected $translatables = array();
 
   /**
+   * The source language of the wrapped entity.
+   * @var string
+   */
+  protected $sourceLanguage;
+
+  /**
    * Creates a Translatable from an Entity wrapper.
    *
    * @param \EntityDrupalWrapper $entityWrapper
@@ -118,11 +124,17 @@ abstract class EntityTranslatableBase implements EntityTranslatableInterface  {
    * {@inheritdoc}
    */
   public function getSourceLanguage() {
+    // If we've already determined the source language, return it.
+    if ($this->sourceLanguage) {
+      return $this->sourceLanguage;
+    }
+
     $language = $this->entity->language->value();
     if ($language === DrupalHandler::LANGUAGE_NONE || empty($language)) {
       $language = $this->drupal->languageDefault('language');
     }
-    return $language;
+    $this->sourceLanguage = $language;
+    return $this->sourceLanguage;
   }
 
   /**

--- a/test/Drupal/Translatable/EntityTranslatableBaseTest.php
+++ b/test/Drupal/Translatable/EntityTranslatableBaseTest.php
@@ -86,6 +86,22 @@ namespace EntityXliff\Drupal\Tests\Translatable {
     }
 
     /**
+     * @test
+     */
+    public function getSourceLanguageCached() {
+      $expectedLanguage = 'en';
+
+      $mockDrupal = $this->getMockHandler();
+      $mockWrapper = $this->getMock('\EntityDrupalWrapper');
+      $translatable = $this->getTranslatableOrNotInstance(TRUE, $mockWrapper, $mockDrupal);
+
+      // Ensure that source language is pulled from a cached value without going
+      // to any value on the provided wrapper.
+      $translatable->setSourceLanguage($expectedLanguage);
+      $this->assertSame($expectedLanguage, $translatable->getSourceLanguage());
+    }
+
+    /**
      * Ensures that EntityTranslatableBase::getData() returns translatable data
      * as expected.
      *
@@ -865,6 +881,14 @@ namespace EntityXliff\Drupal\Tests\Translatable {
      */
     public function setTargetEntities($targetEntities) {
       $this->targetEntities = $targetEntities;
+    }
+
+    /**
+     * Helper method to set the internal source language property for testing.
+     * @param string $sourceLanguage
+     */
+    public function setSourceLanguage($sourceLanguage) {
+      $this->sourceLanguage = $sourceLanguage;
     }
 
     /**

--- a/test/Features/MultipleLanguageImportRegression.feature
+++ b/test/Features/MultipleLanguageImportRegression.feature
@@ -1,0 +1,27 @@
+@api
+Feature: Multiple Language Import (Regression)
+  In order to prove that multiple XLIFFs can be imported without issue
+  Site administrators should be able to
+  Import XLIFF translations for multiple languages through the XLIFF portal
+
+  Background:
+    Given I am logged in as a user with the "administer entity xliff" permission
+
+  Scenario: Import XLIFF through portal
+    Given "page" content:
+      | title              | body                    | promote |
+      | English page title | English page body text. | 1       |
+    When I am on the homepage
+    And follow "English page title"
+    And I click "XLIFF"
+    When I attach fr, de translations of this "English" node
+    And I press the "Import" button
+    Then I should see the success message containing "Successfully imported"
+    And I should not see the message containing "There was a problem importing"
+    When I click "View"
+    And I click "Français"
+    Then I should see the heading "fr page title"
+    And I should see "fr page body text."
+    When I click "Deutsch"
+    Then I should see the heading "de page title"
+    And I should see "de page body text."

--- a/test/scripts/setup_langs.php
+++ b/test/scripts/setup_langs.php
@@ -7,9 +7,10 @@
  */
 
 
-// Create a new language.
+// Create new languages.
 try {
   locale_add_language('fr', 'French', 'Français', LANGUAGE_LTR);
+  locale_add_language('de', 'German', 'Deutsch', LANGUAGE_LTR);
 }
 catch (PDOException $e) {
   echo "Language already installed.\n";


### PR DESCRIPTION
Although this doesn't necessarily resolve the underlying issue, it fixes the only known symptom.

Note the additional behat test in the first commit above (which reproduces the error), followed by the fix just below it (which doesn't introduce new regressions).

Closes #92 
