### PR TITLE
Cover embedded entity cardinality difference regression

### DIFF
--- a/test/Features/Bootstrap/FeatureContext.php
+++ b/test/Features/Bootstrap/FeatureContext.php
@@ -172,16 +172,8 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
     );
     $node = $this->getDriver()->createNode($node);
 
-    // Create and reference related nodes.
-    for ($n = 1; $n <= $n_many; $n++) {
-      $fieldCollectionItem = entity_create('field_collection_item', array('field_name' => 'field_field_collection'));
-      $fieldCollectionItem->setHostEntity('node', $node);
-      $fieldCollectionItem->field_long_text[LANGUAGE_NONE][0] = array(
-        'format' => 'plain_text',
-        'value' => $title . " field collection $n",
-      );
-      $fieldCollectionItem->save();
-    }
+    // Create and reference related field collections.
+    $this->attachSomeFieldCollectionsTo($node, $n_many, $title);
 
     // Resave the original node.
     node_save($node);
@@ -189,6 +181,33 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
 
     // Set internal page on the node.
     $this->getSession()->visit($this->locatePath('/node/' . $node->nid));
+  }
+
+  /**
+   * @Given this :hostentity has :n_many (additional) field collection(s)
+   */
+  public function thisNodeHasSomeNumberOfFieldCollections($hostentity, $n_many) {
+    $session = $this->getSession();
+    $url = $session->getCurrentUrl();
+    $pathPart = $this->entityPathPartMap[$hostentity];
+
+    if (preg_match('/' . preg_quote($pathPart, '/') . '\/(\d+)/', $url, $matches)) {
+      $hostId = $matches[1];
+
+      try {
+        $hostToBeSaved = entity_metadata_wrapper($hostentity, $hostId);
+        $host = $hostToBeSaved->value();
+        $this->attachSomeFieldCollectionsTo($host, $n_many, NULL, $host->language);
+        $hostToBeSaved->set($host);
+        $hostToBeSaved->save();
+      }
+      catch (Exception $e) {
+        throw new Exception('Unable to attach ' . $n_many . ' collections to this ' . $hostentity . ' because ' . $e->getMessage());
+      }
+    }
+    else {
+      throw new Exception('Unable to determine what "this ' . $hostentity . '" is referring to.');
+    }
   }
 
   /**
@@ -248,6 +267,28 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
     }
     $paragraph->save();
     return $paragraph;
+  }
+
+  /**
+   * Attaches the given number of field collections to the given node.
+   * @param object $node
+   * @param int $n_many
+   */
+  protected function attachSomeFieldCollectionsTo($node, $n_many, $title = '', $language = LANGUAGE_NONE) {
+    if (empty($title)) {
+      $title = $node->title;
+    }
+
+    // Create and reference related nodes.
+    for ($n = 1; $n <= $n_many; $n++) {
+      $fieldCollectionItem = entity_create('field_collection_item', array('field_name' => 'field_field_collection'));
+      $fieldCollectionItem->setHostEntity('node', $node, $language);
+      $fieldCollectionItem->field_long_text[LANGUAGE_NONE][0] = array(
+        'format' => 'plain_text',
+        'value' => $title . " field collection $n",
+      );
+      $fieldCollectionItem->save();
+    }
   }
 
   /**

--- a/test/Features/UnsuitableTargetRegression.feature
+++ b/test/Features/UnsuitableTargetRegression.feature
@@ -29,6 +29,27 @@ Feature: Unsuitable Translation Target (Regression)
     And I click "Français"
     Then I should see "fr page title"
 
+  Scenario: Field collection cardinality differs between source and target
+    When I click "English"
+    And I click "Edit"
+    And I fill in "English page title field collection 0" for "field_field_collection[en][0][field_long_text][und][0][value]"
+    And I press "Save"
+    And I click "XLIFF"
+    And I attach a "fr" translation of this "English" node
+    And I press the "Import" button
+    Then I should see the success message containing "Successfully imported"
+    When this node has 2 additional field collections
+    And I click "View"
+    Then I should see "English page title field collection 2"
+    When I click "XLIFF"
+    And I attach a "fr" translation of this "English" node
+    And I press the "Import" button
+    Then I should see the success message containing "Successfully imported"
+    When I click "View"
+    And I click "Français"
+    Then I should see "fr page title field collection 0"
+    And I should see "fr page title field collection 2"
+
   Scenario: Referenced entity added after initial translation
     Given "page" content:
       | title                    | body                     |


### PR DESCRIPTION
Adding a test to catch issue when translate imports would not work when the number of embedded entities  differed between the source translation and the target translation relative to the exported XLIFF.

Note, this was actually resolved as a side effect of #89. Just adding tests here.

Closes #85
