### PR TITLE
Fix translation set corruption caused by Node Reference module

### DIFF
--- a/entity_xliff.module
+++ b/entity_xliff.module
@@ -65,7 +65,9 @@ function entity_xliff_set_xliff($wrapper, $targetLanguage, $xliff, $save = TRUE)
   if ($translatable = entity_xliff_get_translatable($wrapper)) {
     $serializer = entity_xliff_get_serializer($translatable->getSourceLanguage());
     drupal_alter('entity_xliff_set_xliff', $xliff, $wrapper, $targetLanguage);
+    _entity_xliff_should_cancel_node_reference_translation_prep(TRUE);
     $data = $serializer->unserialize($translatable, $targetLanguage, $xliff, $save);
+    _entity_xliff_should_cancel_node_reference_translation_prep(FALSE);
   }
 
   return $data;
@@ -149,6 +151,33 @@ function entity_xliff_entity_info_alter(&$entityInfo) {
   }
   if (module_exists('comment')) {
     $entityInfo['comment']['path'] = 'comment/%comment';
+  }
+}
+
+/**
+ * Implements field_attach_prepare_translation_alter().
+ *
+ * Currently used exclusively to undo the work of the node reference module's
+ * field translation preparation. Its opinions do not mesh with our opinions.
+ *
+ * This ensures that the translation sets of nodes referenced via the node
+ * reference module do not become corrupt on translation import.
+ */
+function entity_xliff_field_attach_prepare_translation_alter(&$entity, $context) {
+  $module_exists = module_exists('node_reference');
+  $is_node = $context['entity_type'] === 'node';
+  $should_cancel = _entity_xliff_should_cancel_node_reference_translation_prep();
+
+  // If we should prevent node reference translation prep (and it's relevant).
+  if ($module_exists && $is_node && $should_cancel) {
+    // Then introspect all node reference fields, go through them, and reset the
+    // node reference value to the original/source value.
+    $references = _entity_xliff_find_node_reference_fields($context['source_entity']);
+
+    // For each entity reference field, go back and set the value from source.
+    foreach ($references as $referenceField) {
+      $entity->{$referenceField} = $context['source_entity']->{$referenceField};
+    }
   }
 }
 
@@ -263,4 +292,59 @@ function _entity_xliff_get_translatable_info() {
   $translatables = module_invoke_all('entity_xliff_translatable_info');
   drupal_alter('entity_xliff_translatable_info', $translatables);
   return $translatables;
+}
+
+/**
+ * Global static setter/getter for whether or not we should cancel the Node
+ * Reference module's field translation preparation step. The only context in
+ * which we care to do so is during XLIFF translation import.
+ *
+ * @param bool $set
+ *   If provided, sets whether or not we should cancel.
+ *
+ * @return bool
+ *   TRUE if the Node Reference module should be ignored. FALSE if it should
+ *   continue to behave as designed.
+ */
+function _entity_xliff_should_cancel_node_reference_translation_prep($set = NULL) {
+  $shouldCancel = &drupal_static(__FUNCTION__, FALSE);
+
+  if ($set !== NULL) {
+    $shouldCancel = $set;
+  }
+
+  return $shouldCancel;
+}
+
+/**
+ * Given a node, return a list of its fields that map to a node reference field.
+ *
+ * @param object $node
+ *   The node to introspect.
+ *
+ * @return array
+ *   An array of field names representing node references. If no node reference
+ *   fields are found, an empty array is returned.
+ */
+function _entity_xliff_find_node_reference_fields($node) {
+  $nodeReferenceFields = array();
+
+  $source = entity_metadata_wrapper('node', $node);
+  $type = $source->getBundle();
+
+  foreach ($source->getPropertyInfo() as $field => $info) {
+    $fieldInfo = field_info_instance('node', $field, $type);
+    if (!isset($fieldInfo['display'])) {
+      break;
+    }
+
+    foreach ($fieldInfo['display'] as $displayInfo) {
+      if (isset($displayInfo['module']) && $displayInfo['module'] === 'node_reference') {
+        $nodeReferenceFields[] = $field;
+        break;
+      }
+    }
+  }
+
+  return $nodeReferenceFields;
 }

--- a/test/Features/AlternateSourceLanguage.feature
+++ b/test/Features/AlternateSourceLanguage.feature
@@ -30,3 +30,4 @@ Feature: Alternative Source Languages
     And I click "English"
     Then I should see the heading "en page title"
     And I should see "en page body text."
+    And there should be no corrupt translation sets.

--- a/test/Features/NodeContentTranslation.feature
+++ b/test/Features/NodeContentTranslation.feature
@@ -36,6 +36,7 @@ Feature: Content Translation of Node and Field Collection Entities
     And I click "Français"
     Then I should see the heading "fr page title"
     And I should see "fr page body text."
+    And there should be no corrupt translation sets.
 
   Scenario: Import collection-based XLIFF through portal
     Given I am viewing a 3 complex "page" content with the title "Complex English page title"
@@ -53,6 +54,7 @@ Feature: Content Translation of Node and Field Collection Entities
     And I should see "Complex fr page title field collection 1"
     And I should see "Complex fr page title field collection 2"
     And I should see "Complex fr page title field collection 3"
+    And there should be no corrupt translation sets.
 
   Scenario: Import paragraph-based XLIFF through portal
     Given I am viewing a "page" content with paragraphs and the title "Paragraph English page title"
@@ -68,6 +70,7 @@ Feature: Content Translation of Node and Field Collection Entities
     Then I should see the heading "Paragraph fr page title"
     And I should see "Paragraph fr page title paragraph 1"
     And I should see "Paragraph fr page title paragraph 2"
+    And there should be no corrupt translation sets.
 
   Scenario: No access to XLIFF portal local task without permissions
     Given I am not logged in

--- a/test/Features/NodeReferences.feature
+++ b/test/Features/NodeReferences.feature
@@ -1,0 +1,70 @@
+@api
+Feature: Node References
+  In order to prove that nodes referenced using the references module are compiled and also translated
+  Site administrators should be able to
+  Import and export XLIFFs through the portal UI including, node references
+
+  Background:
+    Given I am logged in as a user with the "administer entity xliff" permission
+    And "page" content:
+      | title                              | field_long_text                    | promote |
+      | English node host page title       | English node host body text.       | 1       |
+      | English node child page title      | English node child body text.      | 1       |
+      | English node grandchild page title | English node grandchild body text. | 1       |
+    When I am on the homepage
+    And follow "English node child page title"
+    And this node references the "English node grandchild page title" node on the field_node_reference field
+    And I am on the homepage
+    And follow "English node host page title"
+    And this node references the "English node child page title" node on the field_node_reference field
+    When I reload the page
+    Then I should see "English node host page title"
+    And I should see "English node host body text"
+    And I should see "English node child page title"
+    And I should see "English node child body text"
+    And I should see "English node grandchild page title"
+    And I should see "English node grandchild body text"
+
+  Scenario: Export XLIFF through portal
+    Given I am on the homepage
+    And follow "English node host page title"
+    When I click "XLIFF"
+    And I click "Download"
+    Then the response should contain "<xliff"
+    And the response should contain "<source xml:lang=\"en\">English node host page title</source>"
+    And the response should contain "<source xml:lang=\"en\">English node host body text.</source>"
+    And the response should contain "<source xml:lang=\"en\">English node child page title</source>"
+    And the response should contain "<source xml:lang=\"en\">English node child body text.</source>"
+    And the response should contain "<source xml:lang=\"en\">English node grandchild page title</source>"
+    And the response should contain "<source xml:lang=\"en\">English node grandchild body text.</source>"
+
+  Scenario: Import XLIFF through portal
+    Given I am on the homepage
+    And follow "English node host page title"
+    And I click "XLIFF"
+    When I attach a "fr" translation of this "English" node
+    And I press the "Import" button
+    Then I should see the success message containing "Successfully imported"
+    When I click "View"
+    And I click "fr node host page title"
+    Then I should see "fr node host page title"
+    And I should see "fr node host body text"
+    And I should see "fr node child page title"
+    And I should see "fr node child body text"
+    And I should see "fr node grandchild page title"
+    And I should see "fr node grandchild body text"
+    And there should be no corrupt translation sets.
+    # Re-run import to test the pre-initialized case.
+    When I click "English node host page title"
+    And I attach a "fr" translation of this "English" node
+    And I press the "Import" button
+    Then I should see the success message containing "Successfully imported"
+    When I click "View"
+    And I click "fr node host page title"
+    Then I should see "fr node host page title"
+    And I should see "fr node host body text"
+    And I should see "fr node child page title"
+    And I should see "fr node child body text"
+    And I should see "fr node grandchild page title"
+    And I should see "fr node grandchild body text"
+    And there should be no corrupt translation sets.

--- a/test/Features/ReferencedEntities.feature
+++ b/test/Features/ReferencedEntities.feature
@@ -43,3 +43,4 @@ Feature: Referenced Entity Translation
     And I should see "fr host body text"
     And I should see "fr child page title"
     And I should see "fr child body text"
+    And there should be no corrupt translation sets.

--- a/test/scripts/install_drupal.sh
+++ b/test/scripts/install_drupal.sh
@@ -36,8 +36,8 @@ fi
 # Place this module into the sites/all/modules directory and enable it.
 rsync -aq "`pwd`" "`pwd`/$BUILD_DIR/drupal/sites/all/modules/entity_xliff" --exclude build
 pushd $BUILD_DIR/drupal
-  drush --yes dl composer-8.x-1.1 composer_manager link field_collection paragraphs entityreference entity_translation
-  drush --yes en composer_manager translation link entity_translation field_collection paragraphs_i18n entityreference
+  drush --yes dl composer-8.x-1.1 composer_manager link field_collection paragraphs entityreference entity_translation references
+  drush --yes en composer_manager translation link entity_translation field_collection paragraphs_i18n entityreference node_reference
   drush cc drush
   drush --yes en entity_xliff
   drush cc all

--- a/test/scripts/setup_langs.php
+++ b/test/scripts/setup_langs.php
@@ -52,6 +52,7 @@ add_text_field_with_cardinality('node', 'page');
 add_field_collection_field();
 add_paragraphs_field('node', 'page');
 add_entity_reference_field('node', 'page');
+add_node_reference_field('node', 'page');
 
 // Enable entity field translation for appropriate entities.
 $etypes = variable_get('entity_translation_entity_types', array());
@@ -102,6 +103,22 @@ function add_long_text_field($entity, $bundle) {
     'entity_type' => $entity,
     'settings' => array(
       'text_processing' => 1,
+    ),
+    'display' => array(
+      'default' => array(
+        'label' => 'above',
+        'type' => 'text_default',
+        'settings' => array(),
+        'module' => 'text',
+        'weight' => 1,
+      ),
+      'teaser' => array(
+        'label' => 'above',
+        'type' => 'text_default',
+        'weight' => 3,
+        'settings' => array(),
+        'module' => 'text',
+      ),
     ),
   );
 
@@ -426,6 +443,79 @@ function add_entity_reference_field($entity, $bundle) {
 
   // Don't bother if the field already exists.
   if (!field_read_instance($entity, 'field_reference', $bundle)) {
+    // Apply bundle-specific settings.
+    $field_instance_definition['bundle'] = $bundle;
+
+    try {
+      field_create_instance($field_instance_definition);
+    }
+    catch (FieldException $e) {
+      echo "Unable to create text field instance.\n";
+    }
+  }
+}
+
+/**
+ * Adds an entity reference field to the given entity/bundle combination.
+ */
+function add_node_reference_field($entity, $bundle) {
+  if (!$field = field_read_field('field_node_reference')) {
+    try {
+      $field_definition = array(
+        'field_name' => 'field_node_reference',
+        'type' => 'node_reference',
+        'cardinality' => '1',
+        'module' => 'node_reference',
+        'translatable' => FALSE,
+        'settings' => array(
+          'referenceable_types' => array(
+            'page',
+          ),
+          'entity_translation_sync' => FALSE,
+        ),
+      );
+      $field = field_create_field($field_definition);
+    }
+    catch (FieldException $e) {
+      echo "Unable to create field collection field.\n";
+    }
+  }
+
+  $field_instance_definition = array(
+    'label' => 'Node Reference',
+    'field_id' => $field['id'],
+    'required' => FALSE,
+    'description' => '',
+    'field_name' => 'field_node_reference',
+    'entity_type' => $entity,
+    'widget' => array(
+      'type' => 'options_select',
+      'module' => 'options',
+    ),
+    'display' => array(
+      'default' => array(
+        'label' => 'above',
+        'type' => 'node_reference_node',
+        'module' => 'node_reference',
+        'weight' => 8,
+        'settings' => array(
+          'node_reference_view_mode' => 'teaser',
+        ),
+      ),
+      'teaser' => array(
+        'label' => 'above',
+        'type' => 'node_reference_node',
+        'weight' => 2,
+        'settings' => array(
+          'node_reference_view_mode' => 'teaser',
+        ),
+        'module' => 'node_reference',
+      ),
+    ),
+  );
+
+  // Don't bother if the field already exists.
+  if (!field_read_instance($entity, 'field_node_reference', $bundle)) {
     // Apply bundle-specific settings.
     $field_instance_definition['bundle'] = $bundle;
 


### PR DESCRIPTION
Note the new tests (including fail in c9413f7 : [here](https://travis-ci.org/tableau-mkt/entity_xliff/builds/105598551)).
