### PR TITLE
Additional test coverage around translation re-imports

### DIFF
--- a/test/Features/AlternateSourceLanguage.feature
+++ b/test/Features/AlternateSourceLanguage.feature
@@ -26,8 +26,21 @@ Feature: Alternative Source Languages
     When I attach an "en" translation of this "French" node
     And I press the "Import" button
     Then I should see the success message containing "Successfully imported"
+    And there should be no corrupt translation sets.
     When I click "View"
     And I click "English"
     Then I should see the heading "en page title"
     And I should see "en page body text."
+    # Re-import to test the pre-existing/non-initialization flow.
+    When I click "Français"
+    And I click "XLIFF"
+    And I attach an "en" translation of this "French" node
+    And I press the "Import" button
+    Then I should see the success message containing "Successfully imported"
     And there should be no corrupt translation sets.
+    When I click "View"
+    Then I should see the heading "French page title"
+    And I should see "French page body text."
+    When I click "English"
+    Then I should see the heading "en page title"
+    And I should see "en page body text."

--- a/test/Features/MultipleLanguageImportRegression.feature
+++ b/test/Features/MultipleLanguageImportRegression.feature
@@ -18,8 +18,26 @@ Feature: Multiple Language Import (Regression)
     And I press the "Import" button
     Then I should see the success message containing "Successfully imported"
     And I should not see the message containing "There was a problem importing"
+    And there should be no corrupt translation sets.
     When I click "View"
     And I click "Français"
+    Then I should see the heading "fr page title"
+    And I should see "fr page body text."
+    When I click "Deutsch"
+    Then I should see the heading "de page title"
+    And I should see "de page body text."
+    # Re-import to test the pre-existing/non-initialization flow.
+    When I click "English"
+    And I click "XLIFF"
+    And I attach fr, de translations of this "English" node
+    And I press the "Import" button
+    Then I should see the success message containing "Successfully imported"
+    And I should not see the message containing "There was a problem importing"
+    And there should be no corrupt translation sets.
+    When I click "View"
+    Then I should see "English page title"
+    And I should see "English page body text."
+    When I click "Français"
     Then I should see the heading "fr page title"
     And I should see "fr page body text."
     When I click "Deutsch"

--- a/test/Features/NodeContentTranslation.feature
+++ b/test/Features/NodeContentTranslation.feature
@@ -32,11 +32,25 @@ Feature: Content Translation of Node and Field Collection Entities
     When I attach a "fr" translation of this "English" node
     And I press the "Import" button
     Then I should see the success message containing "Successfully imported"
+    And there should be no corrupt translation sets.
     When I click "View"
     And I click "Français"
     Then I should see the heading "fr page title"
     And I should see "fr page body text."
+    # Re-import to test the pre-existing/non-initialization flow.
+    When I click "English"
+    And I click "XLIFF"
+    And I attach a "fr" translation of this "English" node
+    And I press the "Import" button
+    Then I should see the success message containing "Successfully imported"
     And there should be no corrupt translation sets.
+    When I click "View"
+    And I click "Français"
+    Then I should see the heading "fr page title"
+    And I should see "fr page body text."
+    When I click "English"
+    Then I should see the heading "English page title"
+    And I should see "English page body text."
 
   Scenario: Import collection-based XLIFF through portal
     Given I am viewing a 3 complex "page" content with the title "Complex English page title"
@@ -62,6 +76,7 @@ Feature: Content Translation of Node and Field Collection Entities
     And I attach a "fr" translation of this "English" node
     And I press the "Import" button
     Then I should see the success message containing "Successfully imported"
+    And there should be no corrupt translation sets.
     When I click "View"
     Then I should not see the heading "Paragraph fr page title"
     And I should not see "Paragraph fr page title paragraph 1"
@@ -70,7 +85,21 @@ Feature: Content Translation of Node and Field Collection Entities
     Then I should see the heading "Paragraph fr page title"
     And I should see "Paragraph fr page title paragraph 1"
     And I should see "Paragraph fr page title paragraph 2"
+    # Re-import to test the pre-existing/non-initialization flow.
+    When I click "English"
+    And I click "XLIFF"
+    And I attach a "fr" translation of this "English" node
+    And I press the "Import" button
+    Then I should see the success message containing "Successfully imported"
     And there should be no corrupt translation sets.
+    When I click "View"
+    Then I should not see the heading "Paragraph fr page title"
+    And I should not see "Paragraph fr page title paragraph 1"
+    And I should not see "Paragraph fr page title paragraph 2"
+    When I click "Français"
+    Then I should see the heading "Paragraph fr page title"
+    And I should see "Paragraph fr page title paragraph 1"
+    And I should see "Paragraph fr page title paragraph 2"
 
   Scenario: No access to XLIFF portal local task without permissions
     Given I am not logged in

--- a/test/Features/ReferencedEntities.feature
+++ b/test/Features/ReferencedEntities.feature
@@ -37,10 +37,27 @@ Feature: Referenced Entity Translation
     When I attach a "fr" translation of this "English" node
     And I press the "Import" button
     Then I should see the success message containing "Successfully imported"
+    And there should be no corrupt translation sets.
     When I click "View"
     And I click "Français"
     Then I should see "fr host page title"
     And I should see "fr host body text"
     And I should see "fr child page title"
     And I should see "fr child body text"
+    # Re-import to test the pre-existing/non-initialization flow.
+    When I click "English"
+    And I click "XLIFF"
+    And I attach a "fr" translation of this "English" node
+    And I press the "Import" button
+    Then I should see the success message containing "Successfully imported"
     And there should be no corrupt translation sets.
+    When I click "View"
+    Then I should see "English host page title"
+    And I should see "English host body text"
+    And I should see "English child page title"
+    And I should see "English child body text"
+    And I click "Français"
+    Then I should see "fr host page title"
+    And I should see "fr host body text"
+    And I should see "fr child page title"
+    And I should see "fr child body text"


### PR DESCRIPTION
Since the code paths for importing a translation fresh on an as-yet untranslated node and importing a translation for a pre-existing translation set are quite different...  And since there's been instability there recently.  It makes sense to add that to the existing tests to verify that everything works.
