### PR TITLE
Fix HTML entity decode regression

### DIFF
--- a/src/Drupal/FieldHandlers/DefaultFieldHandler.php
+++ b/src/Drupal/FieldHandlers/DefaultFieldHandler.php
@@ -24,7 +24,7 @@ class DefaultFieldHandler implements FieldHandlerInterface {
    * {@inheritdoc}
    */
   public function setValue(\EntityMetadataWrapper $wrapper, $value) {
-    $wrapper->set(html_entity_decode($value));
+    $wrapper->set(html_entity_decode($value, ENT_QUOTES, 'utf-8'));
   }
 
 }

--- a/src/Drupal/FieldHandlers/FormattedFieldHandler.php
+++ b/src/Drupal/FieldHandlers/FormattedFieldHandler.php
@@ -25,7 +25,7 @@ class FormattedFieldHandler implements FieldHandlerInterface {
    */
   public function setValue(\EntityMetadataWrapper $wrapper, $value) {
     $newValue = $wrapper->value();
-    $newValue['value'] = html_entity_decode($value);
+    $newValue['value'] = html_entity_decode($value, ENT_QUOTES, 'utf-8');
     $wrapper->set($newValue);
   }
 

--- a/src/Drupal/FieldHandlers/ImageFieldHandler.php
+++ b/src/Drupal/FieldHandlers/ImageFieldHandler.php
@@ -46,10 +46,10 @@ class ImageFieldHandler implements FieldHandlerInterface {
     $newValue = $wrapper->value();
 
     if (isset($value['alt'])) {
-      $newValue['alt'] = html_entity_decode($value['alt']);
+      $newValue['alt'] = html_entity_decode($value['alt'], ENT_QUOTES, 'utf-8');
     }
     if (isset($value['title'])) {
-      $newValue['title'] = html_entity_decode($value['title']);
+      $newValue['title'] = html_entity_decode($value['title'], ENT_QUOTES, 'utf-8');
     }
 
     $wrapper->set($newValue);

--- a/src/Drupal/FieldHandlers/LinkFieldHandler.php
+++ b/src/Drupal/FieldHandlers/LinkFieldHandler.php
@@ -25,7 +25,7 @@ class LinkFieldHandler implements FieldHandlerInterface {
    */
   public function setValue(\EntityMetadataWrapper $wrapper, $value) {
     $newValue = $wrapper->value();
-    $newValue['title'] = html_entity_decode($value);
+    $newValue['title'] = html_entity_decode($value, ENT_QUOTES, 'utf-8');
     $wrapper->set($newValue);
   }
 

--- a/src/Drupal/FieldHandlers/SummarizedFieldHandler.php
+++ b/src/Drupal/FieldHandlers/SummarizedFieldHandler.php
@@ -48,10 +48,10 @@ class SummarizedFieldHandler implements FieldHandlerInterface {
     $newValue = $wrapper->value();
 
     if (isset($value['value'])) {
-      $newValue['value'] = html_entity_decode($value['value']);
+      $newValue['value'] = html_entity_decode($value['value'], ENT_QUOTES, 'utf-8');
     }
     if (isset($value['summary'])) {
-      $newValue['summary'] = html_entity_decode($value['summary']);
+      $newValue['summary'] = html_entity_decode($value['summary'], ENT_QUOTES, 'utf-8');
     }
 
     $wrapper->set($newValue);

--- a/test/Features/Bootstrap/FeatureContext.php
+++ b/test/Features/Bootstrap/FeatureContext.php
@@ -60,6 +60,10 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
         $translation = str_replace($sourceLang, $targetLang, $xliff);
         $fullPath = $path . DIRECTORY_SEPARATOR . $randomFile;
 
+        // For checking HTML encoded characters.
+        $translation = str_replace('\'', '&amp;#039;', $translation);
+        $translation = str_replace('ç', '&amp;ccedil;', $translation);
+
         // Write the file to the configured path.
         if (file_put_contents($fullPath, $translation)) {
           $files[$targetLang] = $fullPath;

--- a/test/Features/HtmlEntityDecodeRegression.feature
+++ b/test/Features/HtmlEntityDecodeRegression.feature
@@ -1,0 +1,35 @@
+@api
+Feature: Handling for Encoded HTML Entities
+  In order to prove that XLIFFs that include HTML encoded characters can be imported
+  Site administrators should be able to
+  Import and export XLIFF translations that contain HTML encoded entities
+
+  Background:
+    Given I am logged in as a user with the "administer entity xliff" permission
+    # Note: code in FeatureContext.php that replaces single quotes and the "ç"
+    # character with UTF-8 encoded equivalents.
+    And "page" content:
+      | title             | body                                 | language | promote |
+      | French page title | French page body text 'en français.' | fr       | 1       |
+    And I am on the homepage
+    And I follow "French page title"
+
+  Scenario: Access and Export French sourced XLIFF through portal
+    When I click "XLIFF"
+    Then the url should match "node/\d+/xliff"
+    And I should see "Export as XLIFF"
+    And I should see "Import from XLIFF"
+    When I click "Download"
+    Then the response should contain "<xliff"
+    And the response should contain "<source xml:lang=\"fr\">French page title</source>"
+
+  Scenario: Import French sourced XLIFF through portal
+    When I click "XLIFF"
+    When I attach an "en" translation of this "French" node
+    And I press the "Import" button
+    Then I should see the success message containing "Successfully imported"
+    When I click "View"
+    And I click "English"
+    Then I should see the heading "en page title"
+    Then print last response
+    And I should see "en page body text 'en français.'"

--- a/test/Features/HtmlEntityDecodeRegression.feature
+++ b/test/Features/HtmlEntityDecodeRegression.feature
@@ -6,26 +6,17 @@ Feature: Handling for Encoded HTML Entities
 
   Background:
     Given I am logged in as a user with the "administer entity xliff" permission
-    # Note: code in FeatureContext.php that replaces single quotes and the "ç"
-    # character with UTF-8 encoded equivalents.
     And "page" content:
       | title             | body                                 | language | promote |
       | French page title | French page body text 'en français.' | fr       | 1       |
     And I am on the homepage
     And I follow "French page title"
 
-  Scenario: Access and Export French sourced XLIFF through portal
+  Scenario: Import XLIFF containing HTML encoded entities through portal
     When I click "XLIFF"
-    Then the url should match "node/\d+/xliff"
-    And I should see "Export as XLIFF"
-    And I should see "Import from XLIFF"
-    When I click "Download"
-    Then the response should contain "<xliff"
-    And the response should contain "<source xml:lang=\"fr\">French page title</source>"
-
-  Scenario: Import French sourced XLIFF through portal
-    When I click "XLIFF"
-    When I attach an "en" translation of this "French" node
+    # Note: code in FeatureContext.php that replaces single quotes and the "ç"
+    # character with UTF-8 encoded equivalents.
+    And I attach an "en" translation of this "French" node
     And I press the "Import" button
     Then I should see the success message containing "Successfully imported"
     When I click "View"

--- a/test/Features/HtmlEntityDecodeRegression.feature
+++ b/test/Features/HtmlEntityDecodeRegression.feature
@@ -22,5 +22,4 @@ Feature: Handling for Encoded HTML Entities
     When I click "View"
     And I click "English"
     Then I should see the heading "en page title"
-    Then print last response
     And I should see "en page body text 'en français.'"


### PR DESCRIPTION
Decode HTML entities in a manner compatible with the way Drupal and its database handle it.

Note [the test fail here](https://travis-ci.org/tableau-mkt/entity_xliff/builds/106130033) via 0966ba6.  And the [test resolution here](https://travis-ci.org/tableau-mkt/entity_xliff/builds/106130788) via b6224bc.

Closes #95
