### PR TITLE
Better exception handling and messaging

### DIFF
--- a/entity_xliff.module
+++ b/entity_xliff.module
@@ -6,6 +6,7 @@
  */
 
 use EggsCereal\Serializer;
+use EntityXliff\Drupal\Exceptions\EntityStructureDivergedException;
 use EntityXliff\Drupal\Factories\EntityTranslatableFactory;
 
 
@@ -63,10 +64,27 @@ function entity_xliff_set_xliff($wrapper, $targetLanguage, $xliff, $save = TRUE)
   $data = array();
 
   if ($translatable = entity_xliff_get_translatable($wrapper)) {
+    // Start a database transaction in case we have to rollback an import.
+    $transaction = db_transaction();
+
+    // Prepare for XLIFF import.
     $serializer = entity_xliff_get_serializer($translatable->getSourceLanguage());
     drupal_alter('entity_xliff_set_xliff', $xliff, $wrapper, $targetLanguage);
     _entity_xliff_should_cancel_node_reference_translation_prep(TRUE);
-    $data = $serializer->unserialize($translatable, $targetLanguage, $xliff, $save);
+
+    try {
+      $data = $serializer->unserialize($translatable, $targetLanguage, $xliff, $save);
+    }
+    catch (EntityStructureDivergedException $e) {
+      drupal_set_message(t('The structure of %label has changed since the @lang XLIFF was exported. You will need to re-export and try again.', array(
+        '%label' => $wrapper->label(),
+        '@lang' => $targetLanguage,
+      )), 'error');
+      $transaction->rollback();
+      $data = array();
+    }
+
+    // Clean up after XLIFF import.
     _entity_xliff_should_cancel_node_reference_translation_prep(FALSE);
   }
 

--- a/src/Drupal/Exceptions/EntityStructureDivergedException.php
+++ b/src/Drupal/Exceptions/EntityStructureDivergedException.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @file
+ * Contains EntityXliff\Drupal\Exceptions\EntityStructureDivergedException.
+ */
+
+namespace EntityXliff\Drupal\Exceptions;
+
+/**
+ * Class EntityStructureDivergedException
+ *
+ * Thrown when the structure of a piece of content has diverged sufficiently
+ * from the structure implied by an XLIFF on import such that the import cannot
+ * continue.
+ *
+ * @package EntityXliff\Drupal\Exceptions
+ */
+class EntityStructureDivergedException extends \RuntimeException {
+
+}

--- a/src/Drupal/Translatable/EntityTranslatableBase.php
+++ b/src/Drupal/Translatable/EntityTranslatableBase.php
@@ -8,6 +8,7 @@
 namespace EntityXliff\Drupal\Translatable;
 
 use EggsCereal\Utils\Data;
+use EntityXliff\Drupal\Exceptions\EntityStructureDivergedException;
 use EntityXliff\Drupal\Factories\EntityTranslatableFactory;
 use EntityXliff\Drupal\Interfaces\EntityTranslatableInterface;
 use EntityXliff\Drupal\Mediator\EntityMediator;
@@ -334,15 +335,19 @@ abstract class EntityTranslatableBase implements EntityTranslatableInterface  {
    * @param array $parents
    * @param $value
    * @param $targetLang
+   * @throws EntityStructureDivergedException
    */
   protected function entitySetNestedValue(\EntityMetadataWrapper $wrapper, array $parents, $value, $targetLang) {
     // Get the field reference.
     $ref = array_shift($parents);
-    if (is_numeric($ref)) {
+    if (is_numeric($ref) && isset($wrapper[$ref])) {
       $field = &$wrapper[$ref]; // @codeCoverageIgnoreStart
     } // @codeCoverageIgnoreEnd
-    else {
+    elseif (isset($wrapper->{$ref})) {
       $field = &$wrapper->{$ref};
+    }
+    else {
+      throw new EntityStructureDivergedException('XLIFF serialized structure has diverged from Drupal content structure: ' . $ref);
     }
 
     // Base case: we are setting a basic field on an entity.

--- a/test/Drupal/Translatable/EntityTranslatableBaseTest.php
+++ b/test/Drupal/Translatable/EntityTranslatableBaseTest.php
@@ -527,6 +527,27 @@ namespace EntityXliff\Drupal\Tests\Translatable {
     }
 
     /**
+     * Ensures that the expected exception is thrown when attempting to set a
+     * field that no longer exists on the source content.
+     *
+     * @test
+     * @expectedException \EntityXliff\Drupal\Exceptions\EntityStructureDivergedException
+     */
+    public function entitySetNestedValueBaseCaseStaleXliffStructure() {
+      $givenField = 'title';
+      $givenParents = array($givenField);
+      $givenValue = 'Value';
+      $givenTargetLang = 'de';
+
+      $mockEntity = $this->getMockWrapper();
+      $observerWrapper = $this->getMock('\EntityDrupalWrapper');
+      $observerMediator = $this->getMockMediator();
+
+      $translatable = new EntityTranslatableMockForEntitySetNestedValue($mockEntity, NULL, NULL, $observerMediator);
+      $translatable->entitySetNestedValue($observerWrapper, $givenParents, $givenValue, $givenTargetLang);
+    }
+
+    /**
      * Ensures that EntityTranslatableBase::entitySetNestedValue() returns FALSE
      * in the case that the given field is not known to be translated.
      *

--- a/test/Features/Bootstrap/FeatureContext.php
+++ b/test/Features/Bootstrap/FeatureContext.php
@@ -34,7 +34,7 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
   /**
    * @When /^I attach(?:| a(?:|n)) (?:|")([^"]+)(?:|") translation(?:|s) of this "([^"]+)" ([^"]+)$/
    */
-  public function iAttachATranslationOfThisEntity($targetLangs, $sourceLang, $entity) {
+  public function iAttachATranslationOfThisEntity($targetLangs, $sourceLang, $entity, $outdatedField = FALSE) {
     $baseUrl = $this->getMinkParameter('base_url');
     $path = $this->getMinkParameter('files_path');
     $session = $this->getSession();
@@ -64,6 +64,10 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
         $translation = str_replace('\'', '&amp;#039;', $translation);
         $translation = str_replace('ç', '&amp;ccedil;', $translation);
 
+        if ($outdatedField) {
+          $translation = str_replace('="body"', '="old_body"', $translation);
+        }
+
         // Write the file to the configured path.
         if (file_put_contents($fullPath, $translation)) {
           $files[$targetLang] = $fullPath;
@@ -84,6 +88,13 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
     else {
       throw new Exception('Unable to determine what "this ' . $entity . '" is referring to.');
     }
+  }
+
+  /**
+   * @When I attach an outdated translation of this :entity
+   */
+  public function iAttachAnOutdatedTranslationOfThisEntity($entity) {
+    $this->iAttachATranslationOfThisEntity('fr, de', 'English', $entity, TRUE);
   }
 
   /**

--- a/test/Features/ContentStructureDiverged.feature
+++ b/test/Features/ContentStructureDiverged.feature
@@ -1,0 +1,25 @@
+@api
+Feature: Content structure divergence
+  In order to prove that attempts to import stale XLIFFs are safe
+  Site administrators should be able to
+  Attempt to import XLIFF translations with outdated field structures and receive useful error messaging
+
+  Background:
+    Given I am logged in as a user with the "administer entity xliff,bypass node access" permission
+    And "page" content:
+      | title                    | body                          | language  | promote |
+      | Outdated structure title | Exact contents do not matter. | und       | 1       |
+    And I am on the homepage
+    And I follow "Outdated structure title"
+
+  Scenario: Attempt to import XLIFF with outdated field structures
+    When I click "XLIFF"
+    And I attach an outdated translation of this node
+    And I press the "Import" button
+    Then I should not see the message containing "Successfully imported"
+    # @todo: Then I should see the error message containing "You will need to re-export and try again."
+    And there should be no corrupt translation sets.
+    When I click "Edit"
+    # Ensures database transaction rollback occurred (the initialization of the
+    # node from language neutral to English should be reverted).
+    Then I should see "Language neutral" in the "#edit-language" element

--- a/test/Features/ContentStructureDiverged.feature
+++ b/test/Features/ContentStructureDiverged.feature
@@ -16,9 +16,9 @@ Feature: Content structure divergence
     When I click "XLIFF"
     And I attach an outdated translation of this node
     And I press the "Import" button
-    Then I should not see the message containing "Successfully imported"
-    # @todo: Then I should see the error message containing "You will need to re-export and try again."
-    And there should be no corrupt translation sets.
+    Then there should be no corrupt translation sets.
+    And I should not see the message containing "Successfully imported"
+    And I should see the error message containing "You will need to re-export and try again."
     When I click "Edit"
     # Ensures database transaction rollback occurred (the initialization of the
     # node from language neutral to English should be reverted).


### PR DESCRIPTION
- Prevents Entity Metadata Wrapper exceptions when attempting to set content on non-existent fields, provides more useful error messaging for that case.
- In such cases, introduces database transaction rollbacks, ensuring we don't end up with partially imported nodes or otherwise broken translations

Closes #103.
