### PR TITLE
Catch error when nodes in set go "out of phase"

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ __Paragraphs__: If you use this module with Paragraphs, you will need this patch
 to avoid issues where paragraphs items seem to disappear as you import XLIFFs:
 https://www.drupal.org/node/2621866
 
+__Workbench Moderation__: If you use this module with Workbench Moderation, you
+will need to apply this patch to avoid fatal errors during XLIFF import failures:
+https://www.drupal.org/node/2664018
+
 ## Developing with this module
 @todo
 

--- a/entity_xliff.module
+++ b/entity_xliff.module
@@ -6,6 +6,7 @@
  */
 
 use EggsCereal\Serializer;
+use EntityXliff\Drupal\Exceptions\EntityDataGoneAwayException;
 use EntityXliff\Drupal\Exceptions\EntityStructureDivergedException;
 use EntityXliff\Drupal\Factories\EntityTranslatableFactory;
 
@@ -76,7 +77,17 @@ function entity_xliff_set_xliff($wrapper, $targetLanguage, $xliff, $save = TRUE)
       $data = $serializer->unserialize($translatable, $targetLanguage, $xliff, $save);
     }
     catch (EntityStructureDivergedException $e) {
+      watchdog_exception('entity xliff', $e);
       drupal_set_message(t('The structure of %label has changed since the @lang XLIFF was exported. You will need to re-export and try again.', array(
+        '%label' => $wrapper->label(),
+        '@lang' => $targetLanguage,
+      )), 'error');
+      $transaction->rollback();
+      $data = array();
+    }
+    catch (EntityDataGoneAwayException $e) {
+      watchdog_exception('entity xliff', $e);
+      drupal_set_message(t('The @lang XLIFF import for %label failed due to a prior import failure. Check logs for entity xliff failures and resolve them.', array(
         '%label' => $wrapper->label(),
         '@lang' => $targetLanguage,
       )), 'error');

--- a/src/Drupal/Exceptions/EntityDataGoneAwayException.php
+++ b/src/Drupal/Exceptions/EntityDataGoneAwayException.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @file
+ * Contains EntityXliff\Drupal\Exceptions\EntityDataGoneAwayException.
+ */
+
+namespace EntityXliff\Drupal\Exceptions;
+
+/**
+ * Class EntityDataGoneAwayException
+ *
+ * Thrown when an EntityTranslatable is unable to load the underlying data in an
+ * \EntityDrupalWrapper. This can happen when an import relies on the existence
+ * of a node in a translation set which has gone out of phase due to a previous
+ * database transaction rollback.
+ *
+ * Resolving the issue that caused the original database rollback will resolve
+ * this problem as well.
+ *
+ * @package EntityXliff\Drupal\Exceptions
+ */
+class EntityDataGoneAwayException extends \RuntimeException {
+
+}

--- a/src/Drupal/Translatable/Content/NodeTranslatable.php
+++ b/src/Drupal/Translatable/Content/NodeTranslatable.php
@@ -131,10 +131,9 @@ class NodeTranslatable extends EntityTranslatableBase {
    * translation set.
    */
   public function initializeTranslation() {
-    $nid = (int) $this->entity->getIdentifier();
-    $source = $this->drupal->nodeLoad($nid, NULL, TRUE);
+    $source = $this->getRawEntity($this->entity);
     if ($source->language === DrupalHandler::LANGUAGE_NONE || empty($source->tnid)) {
-      $source->tnid = $nid;
+      $source->tnid = $source->nid;
       $source->language = $this->getSourceLanguage();
       $this->drupal->nodeSave($source);
       $this->entity = $this->drupal->entityMetadataWrapper('node', $source);

--- a/src/Drupal/Translatable/EntityTranslatableBase.php
+++ b/src/Drupal/Translatable/EntityTranslatableBase.php
@@ -8,6 +8,7 @@
 namespace EntityXliff\Drupal\Translatable;
 
 use EggsCereal\Utils\Data;
+use EntityXliff\Drupal\Exceptions\EntityDataGoneAwayException;
 use EntityXliff\Drupal\Exceptions\EntityStructureDivergedException;
 use EntityXliff\Drupal\Factories\EntityTranslatableFactory;
 use EntityXliff\Drupal\Interfaces\EntityTranslatableInterface;
@@ -397,6 +398,7 @@ abstract class EntityTranslatableBase implements EntityTranslatableInterface  {
           if ($translatable = $this->translatableFactory->getTranslatable($field)) {
             $translatable->initializeTranslation();
             $field = $translatable->getTargetEntity($targetLang);
+            $targetId = $field->getIdentifier();
           }
         }
 
@@ -485,6 +487,8 @@ abstract class EntityTranslatableBase implements EntityTranslatableInterface  {
    *
    * @return mixed
    *   The raw entity object.
+   *
+   * @throws EntityDataGoneAwayException
    */
   public function getRawEntity(\EntityDrupalWrapper $wrapper) {
     $raw = $wrapper->raw();
@@ -492,6 +496,12 @@ abstract class EntityTranslatableBase implements EntityTranslatableInterface  {
       $entities = $this->drupal->entityLoad($wrapper->type(), array((int) $raw));
       $raw = reset($entities);
     }
+
+    // If we still don't have an object to serve back, something is wrong.
+    if (!is_object($raw)) {
+      throw new EntityDataGoneAwayException('Underlying entity lost during processing.');
+    }
+
     return $raw;
   }
 

--- a/test/Drupal/Translatable/EntityTranslatableBaseTest.php
+++ b/test/Drupal/Translatable/EntityTranslatableBaseTest.php
@@ -654,9 +654,9 @@ namespace EntityXliff\Drupal\Tests\Translatable {
 
       $observerWrapper = $this->getMock('\EntityMetadataWrapper');
       $observerWrapper->{$givenBaseField} = $this->getMock('\EntityDrupalWrapper', array('getIdentifier', 'type', 'set'));
-      $observerWrapper->{$givenBaseField}->expects($this->exactly(4))
+      $observerWrapper->{$givenBaseField}->expects($this->exactly(5))
         ->method('getIdentifier')
-        ->willReturnOnConsecutiveCalls(FALSE, $expectedIdentifier, $expectedIdentifier, $expectedIdentifier);
+        ->willReturnOnConsecutiveCalls(FALSE, FALSE, $expectedIdentifier, $expectedIdentifier, $expectedIdentifier);
       $observerWrapper->{$givenBaseField}->expects($this->any())
         ->method('type')
         ->willReturn($expectedType);


### PR DESCRIPTION
Catches a fatal error when a translation import attempts to move forward when a prior import on the same request fails and is rolled back, but the subsequent import depends on a translation set that occurred in the prior import.

Throws an error message to end-users indicating that if they resolve the issue that caused the first error, it will resolve the current issue. 

Closes #108
