### PR TITLE
Revert "Quick fix for workbench moderation current revision support"

### DIFF
--- a/src/Drupal/Factories/EntityTranslatableFactory.php
+++ b/src/Drupal/Factories/EntityTranslatableFactory.php
@@ -112,7 +112,6 @@ class EntityTranslatableFactory {
       $paradigm = $this->getTranslationParadigm($wrapper);
       if (isset($this->classMap[$type][$paradigm])) {
         $translatable = $this->classMap[$type][$paradigm];
-        $this->drupal->entityXliffLoadModuleIncs();
         $this->drupal->alter('entity_xliff_translatable_source', $wrapper, $type);
         $this->translatables[$key] = new $translatable($wrapper);
       }

--- a/test/Drupal/Factories/EntityTranslatableFactoryTest.php
+++ b/test/Drupal/Factories/EntityTranslatableFactoryTest.php
@@ -82,7 +82,7 @@ class EntityTranslatableFactoryTest extends \PHPUnit_Framework_TestCase {
       ),
     );
 
-    $observerDrupal = $this->getMock('EntityXliff\Drupal\Utils\DrupalHandler', array('entityGetInfo', 'alter', 'entityXliffLoadModuleIncs'));
+    $observerDrupal = $this->getMock('EntityXliff\Drupal\Utils\DrupalHandler', array('entityGetInfo', 'alter'));
 
     $observerWrapper = $this->getMock('\EntityDrupalWrapper', array('type', 'getIdentifier'));
     $observerWrapper->expects($this->once())
@@ -91,10 +91,6 @@ class EntityTranslatableFactoryTest extends \PHPUnit_Framework_TestCase {
     $observerWrapper->expects($this->once())
       ->method('getIdentifier')
       ->willReturn($expectedIdentifier);
-
-    // Ensure module INCs are included.
-    $observerDrupal->expects($this->once())
-      ->method('entityXliffLoadModuleIncs');
 
     // Ensure the alter hook is called on the provided, wrapped entity.
     $observerDrupal->expects($this->once())


### PR DESCRIPTION
Looks like we'll want integration tests that account for Workbench Moderation support...  This resolved the issue of pulling the latest revision, but it completely broke imports.
