### PR TITLE
Better handling of Module includes

### DIFF
--- a/entity_xliff.admin.inc
+++ b/entity_xliff.admin.inc
@@ -27,7 +27,7 @@ function entity_xliff_actions($form, &$form_state) {
   $rows = array();
   foreach (language_list() as $langcode => $language) {
     // Generate a link to download / export this entity as XLIFF.
-    $export_link = l('Download', $path . '/as.xlf', array(
+    $export_link = l('Download', $path . '/as-xlf', array(
       'query' => array(
         'targetLang' => $langcode,
       ),

--- a/entity_xliff.module
+++ b/entity_xliff.module
@@ -132,7 +132,7 @@ function entity_xliff_menu() {
 
       // Callback to render an entity as an XLIFF file.
       $entityLabel = isset($entityInfo['label']) ? $entityInfo['label'] : 'Entity';
-      $menu[$entityInfo['path'] . '/as.xlf'] = array(
+      $menu[$entityInfo['path'] . '/as-xlf'] = array(
         'title' =>  $entityLabel . ' XLIFF',
         'type' => MENU_CALLBACK,
         'file' => 'entity_xliff.pages.inc',

--- a/entity_xliff.module
+++ b/entity_xliff.module
@@ -263,6 +263,13 @@ function entity_xliff_get_field_handlers() {
 }
 
 /**
+ *  Always load the entity_xliff includes to ensure their alters are invoked.
+ */
+function entity_xliff_init() {
+  _entity_xliff_load_module_incs();
+}
+
+/**
  * Loads in includes provided on behalf of existing modules.
  */
 function _entity_xliff_load_module_incs() {

--- a/modules/workbench_moderation.entity_xliff.inc
+++ b/modules/workbench_moderation.entity_xliff.inc
@@ -12,8 +12,9 @@ if (!function_exists('workbench_moderation_entity_xliff_translatable_source_alte
    * Implements hook_entity_xliff_translatable_source_alter().
    */
   function workbench_moderation_entity_xliff_translatable_source_alter(&$wrapper, $type) {
-    if ($type === 'node') {
+    if ($type === 'node' && !empty($wrapper->id)) {
       // If workbench moderation is enabled for this content type...
+      // And this is a source node (i.e. it is not an unsaved target with no ID)
       if (workbench_moderation_node_type_moderated($wrapper->getBundle())) {
         // Then wrap the current revision, not the live version.
         $node = workbench_moderation_node_current_load($wrapper->value());

--- a/test/Features/AlternateSourceLanguage.feature
+++ b/test/Features/AlternateSourceLanguage.feature
@@ -26,7 +26,6 @@ Feature: Alternative Source Languages
     When I click "XLIFF"
     When I attach an "en" translation of this "French" node
     And I press the "Import" button
-
     Then I should see the success message containing "Successfully imported"
     And there should be no corrupt translation sets.
     When I click "Translate"

--- a/test/Features/AlternateSourceLanguage.feature
+++ b/test/Features/AlternateSourceLanguage.feature
@@ -26,6 +26,7 @@ Feature: Alternative Source Languages
     When I click "XLIFF"
     When I attach an "en" translation of this "French" node
     And I press the "Import" button
+
     Then I should see the success message containing "Successfully imported"
     And there should be no corrupt translation sets.
     When I click "Translate"

--- a/test/Features/Bootstrap/FeatureContext.php
+++ b/test/Features/Bootstrap/FeatureContext.php
@@ -80,7 +80,7 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
 
         // Load the XLIFF file for this node.
         $this->getSession()
-          ->visit($baseUrl . "/$pathPart/$id/as.xlf?targetLang=$targetLang");
+          ->visit($baseUrl . "/$pathPart/$id/as-xlf?targetLang=$targetLang");
         $xliff = $session->getPage()->getContent();
 
         // "Translate" the file.

--- a/test/Features/SourceContentOverwriteRegression.feature
+++ b/test/Features/SourceContentOverwriteRegression.feature
@@ -19,24 +19,20 @@ Feature: Source Content Overrrite (Regression)
   Scenario: Import over existing translation set (focus on field collections)
     When I click "Translate"
     And I click "English page title"
-    And I click "New draft"
-    And I press "Save"
-    And I click "New draft"
-    And I fill in "English field collection" for "field_field_collection[en][0][field_long_text][und][0][value]"
-    And I press "Save"
+    Given this node has 1 field collection
     And I click "XLIFF"
     And I attach a "fr" translation of this "English" node
     And I press the "Import" button
     Then I should see the success message containing "Successfully imported"
     When I click "View published"
-    Then I should see "English field collection"
+    Then I should see "English page title field collection 1"
     When I click "XLIFF"
     And I attach a "fr" translation of this "English" node
     And I press the "Import" button
     Then I should see the success message containing "Successfully imported"
     When I click "View published"
-    Then I should see "English field collection"
-    And I should not see "fr field collection"
+    Then I should see "English page title field collection 1"
+    And I should not see "fr page title field collection 1"
 
   Scenario: Import over existing translation set (focus on entity references)
     Given "page" content:

--- a/test/scripts/install_drupal.sh
+++ b/test/scripts/install_drupal.sh
@@ -46,8 +46,8 @@ popd
 
 # Patch field collection module.
 pushd $BUILD_DIR/drupal/sites/all/modules/field_collection
-  curl https://www.drupal.org/files/issues/1937866-field_collection-metadata-setter-6.patch | patch -p1
-  curl https://www.drupal.org/files/issues/field_collection-logic-issue-with-fetchHostDetails-2382089-23.patch | patch -p1
+  #curl https://www.drupal.org/files/issues/1937866-field_collection-metadata-setter-6.patch | patch -p1
+  #curl https://www.drupal.org/files/issues/field_collection-logic-issue-with-fetchHostDetails-2382089-23.patch | patch -p1
 popd
 
 # Patch paragraphs module.


### PR DESCRIPTION
1. Fix tests.

- Replace as.xlf with as-xlf (drush runserver bug)
- Do not create field_collection items though the UI.

2. Always load module includes to ensure their alters are invoked correctly. (Closes #113)