### PR TITLE
Codesink

### DIFF
--- a/entity_xliff.module
+++ b/entity_xliff.module
@@ -94,6 +94,26 @@ function entity_xliff_set_xliff($wrapper, $targetLanguage, $xliff, $save = TRUE)
       $transaction->rollback();
       $data = array();
     }
+    catch(\PDOException $e){
+      // Catch any general pdo exceptions (i.e. data too long for field) scoped to the global namespace via \Exception.
+      watchdog_exception('entity xliff', $e);
+      drupal_set_message(t('The @lang XLIFF import for %label failed with a database pdo error. Check logs for entity xliff failures and resolve them.', array(
+        '%label' => $wrapper->label(),
+        '@lang' => $targetLanguage,
+      )), 'error');
+      $transaction->rollback();
+      $data = array();
+    }
+    catch(\Exception $e){
+      // Catch ALL exceptions otherwise the transaction won't roll back and we risk corrupted entitites.
+      watchdog_exception('entity xliff', $e);
+      drupal_set_message(t('The @lang XLIFF import for %label failed. Check logs for entity xliff failures and resolve them.', array(
+        '%label' => $wrapper->label(),
+        '@lang' => $targetLanguage,
+      )), 'error');
+      $transaction->rollback();
+      $data = array();
+    }
 
     // Clean up after XLIFF import.
     _entity_xliff_should_cancel_node_reference_translation_prep(FALSE);

--- a/modules/field_collection.entity_xliff.inc
+++ b/modules/field_collection.entity_xliff.inc
@@ -28,6 +28,9 @@ if (!function_exists('field_collection_entity_xliff_translatable_fields_alter'))
         $fields[] = $field;
       }
     }
+    // If multiple alters alter this entity there can be gaps in the $fields array that throw warnings.
+    // Reindex the array before returning.
+    $fields = array_values($fields);
   }
 
 }

--- a/modules/paragraphs_i18n.entity_xliff.inc
+++ b/modules/paragraphs_i18n.entity_xliff.inc
@@ -47,6 +47,9 @@ if (!function_exists('paragraphs_i18n_entity_xliff_translatable_fields_alter')) 
         $fields[] = $field;
       }
     }
+    // If multiple alters alter this entity there can be gaps in the $fields array that throw warnings.
+    // Reindex the array before returning.
+    $fields = array_values($fields);
   }
 
 }

--- a/src/Drupal/Translatable/EntityTranslatableBase.php
+++ b/src/Drupal/Translatable/EntityTranslatableBase.php
@@ -428,9 +428,20 @@ abstract class EntityTranslatableBase implements EntityTranslatableInterface  {
 
           if (is_numeric($ref)) {
             // @codeCoverageIgnoreStart
-            $vals = $wrapper->raw();
-            $vals[$ref] = $field->getIdentifier();
-            $wrapper->set($vals);
+            try {
+              $vals = $wrapper->raw();
+              // If Entity API is patched to allow setting raw entities in list
+              // wrappers, then set the raw entity.
+              // @see https://www.drupal.org/node/1587882
+              $vals[$ref] = $field->raw();
+              $wrapper->set($vals);
+            }
+            catch (\Exception $e) {
+              // Otherwise, we have to set the entity identifier alone.
+              $vals = $wrapper->raw();
+              $vals[$ref] = $field->getIdentifier();
+              $wrapper->set($vals);
+            }
           } // @codeCoverageIgnoreEnd
           else {
             $wrapper->{$ref}->set($field->getIdentifier());


### PR DESCRIPTION
Pull in fixes from external repo (Tableau WWW)

1. Patch against updated entity API (https://www.drupal.org/node/1587882)
1. Fix duplicated paragraphs items which should be revisions 
1. Catch PDO and general exceptions
1. Fix warnings on complex entities with both paragraphs and field collections or multiple fields of either.

