### PR TITLE
Use current revisions and don't unpublish anything!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ before_script:
 script:
   - phpunit --coverage-text --coverage-clover build/logs/clover.xml
   - if [ $BDD = 'true' ] ; then behat --suite=contentTranslation --verbose ; fi
+  - if [ $BDD = 'true' ] ; then ./build/drupal drush en entity_translation --y ; fi
   - if [ $BDD = 'true' ] ; then behat --suite=entityTranslation --verbose ; fi
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,11 +65,13 @@ before_script:
 
 script:
   - phpunit --coverage-text --coverage-clover build/logs/clover.xml
-  - if [ $BDD = 'true' ] ; then behat --suite=contentTranslation --verbose ; fi
-  - if [ $BDD = 'true' ] ; then pushd build/drupal ; fi
-  - if [ $BDD = 'true' ] ; then drush en entity_translation --y ; fi
-  - if [ $BDD = 'true' ] ; then popd ; fi
   - if [ $BDD = 'true' ] ; then behat --suite=entityTranslation --verbose ; fi
+  # Disable entity_translation to run content translation tests.
+  - if [ $BDD = 'true' ] ; then pushd build/drupal ; fi
+  - if [ $BDD = 'true' ] ; then drush dis entity_translation --y ; fi
+  - if [ $BDD = 'true' ] ; then popd ; fi
+  - if [ $BDD = 'true' ] ; then behat --suite=contentTranslation --verbose ; fi
+
 
 after_script:
   - ./vendor/bin/test-reporter --stdout > build/logs/coverage.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,9 @@ before_script:
 script:
   - phpunit --coverage-text --coverage-clover build/logs/clover.xml
   - if [ $BDD = 'true' ] ; then behat --suite=contentTranslation --verbose ; fi
-  - if [ $BDD = 'true' ] ; then ./build/drupal drush en entity_translation --y ; fi
+  - if [ $BDD = 'true' ] ; then pushd build/drupal ; fi
+  - if [ $BDD = 'true' ] ; then drush en entity_translation --y ; fi
+  - if [ $BDD = 'true' ] ; then popd ; fi
   - if [ $BDD = 'true' ] ; then behat --suite=entityTranslation --verbose ; fi
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,9 +67,7 @@ script:
   - phpunit --coverage-text --coverage-clover build/logs/clover.xml
   - if [ $BDD = 'true' ] ; then behat --suite=entityTranslation --verbose ; fi
   # Disable entity_translation to run content translation tests.
-  - if [ $BDD = 'true' ] ; then pushd build/drupal ; fi
-  - if [ $BDD = 'true' ] ; then drush dis entity_translation --y ; fi
-  - if [ $BDD = 'true' ] ; then popd ; fi
+  - if [ $BDD = 'true' ] ; then pushd build/drupal && drush dis entity_translation --y && popd ; fi
   - if [ $BDD = 'true' ] ; then behat --suite=contentTranslation --verbose ; fi
 
 

--- a/modules/workbench_moderation.entity_xliff.inc
+++ b/modules/workbench_moderation.entity_xliff.inc
@@ -29,6 +29,7 @@ if (!function_exists('workbench_moderation_entity_xliff_translatable_source_alte
           // Then force the curent node to stay draft!
           $current_node->workbench_moderation_state_new = workbench_moderation_state_none();
           $wrapper->set($current_node);
+          // Save happens in calling function.
         }
       }
     }
@@ -90,7 +91,7 @@ if (!function_exists('workbench_moderation_entity_xliff_presave_alter')) {
    */
   function workbench_moderation_entity_xliff_presave_alter(&$wrapper, $type) {
 
-    if ($wrapper->type() === 'node') {
+    if ($wrapper->type() === 'node' && workbench_moderation_node_type_moderated($wrapper->getBundle())) {
 
       $node = $wrapper->value();
       $id = $wrapper->getIdentifier();

--- a/modules/workbench_moderation.entity_xliff.inc
+++ b/modules/workbench_moderation.entity_xliff.inc
@@ -18,13 +18,17 @@ if (!function_exists('workbench_moderation_entity_xliff_translatable_source_alte
       // And this is a source node (i.e. it is not an unsaved target with no ID)
       if (workbench_moderation_node_type_moderated($wrapper->getBundle())) {
         // Then wrap the current revision, not the live version.
-        $node = workbench_moderation_node_current_load($wrapper->value());
-        // If this has not been saved yet it will return false, in which case just use the wrapper.
-        if ($node) {
-          // Force workbench to maintain the current state of the source node.
-          // If status = 1 then, keep it published otherwise keep it in draft.
-          $node->workbench_moderation_state_new = $node->status ? workbench_moderation_state_published() : workbench_moderation_state_none();
-          $wrapper->set($node);
+        $current_node = workbench_moderation_node_current_load($wrapper->value());
+        $published_node = node_load($id);
+        if ($current_node->vid != $published_node->vid) {
+          // There is a published node and a current Draft.
+          // First force the published node to stay published
+          $wrapper->set($published_node);
+          $published_node->workbench_moderation_state_new = workbench_moderation_state_published();
+          $wrapper->save();
+          // Then force the curent node to stay draft!
+          $current_node->workbench_moderation_state_new = workbench_moderation_state_none();
+          $wrapper->set($current_node);
         }
       }
     }
@@ -52,9 +56,6 @@ if (!function_exists('workbench_moderation_entity_xliff_target_entities_alter'))
           // Then use the current node revision, which is not necessarily the published one.
           $current_node = workbench_moderation_node_current_load($node_to_alter);
           if ($current_node) {
-            // Force workbench to maintain the current state of the source node.
-            // If status = 1 then, keep it published otherwise keep it in draft.
-            $current_node->workbench_moderation_state_new = $current_node->status ? workbench_moderation_state_published() : workbench_moderation_state_none();
             $node_to_alter = $current_node;
           }
         }
@@ -90,8 +91,10 @@ if (!function_exists('workbench_moderation_entity_xliff_presave_alter')) {
   function workbench_moderation_entity_xliff_presave_alter(&$wrapper, $type) {
 
     if ($wrapper->type() === 'node') {
+
       $node = $wrapper->value();
-      if ($node->nid) {
+      $id = $wrapper->getIdentifier();
+      if (!empty($id)) {
         $current_node = workbench_moderation_node_current_load($node);
         $published_node = node_load($node->nid);
         if ($current_node->vid != $published_node->vid) {
@@ -102,8 +105,9 @@ if (!function_exists('workbench_moderation_entity_xliff_presave_alter')) {
         }
       }else{
         // This is a brand new target, remove any workbench stuff left from the source.
+        // Force it to follow the default that is set in workbench.
         unset($node->workbench_moderation);
-        unset($node->workbench_moderation_state_new);
+        $node->workbench_moderation_state_new = variable_get('workbench_moderation_default_state_' . $node->type, workbench_moderation_state_none());
       }
 
     }

--- a/modules/workbench_moderation.entity_xliff.inc
+++ b/modules/workbench_moderation.entity_xliff.inc
@@ -21,13 +21,15 @@ if (!function_exists('workbench_moderation_entity_xliff_translatable_source_alte
         $node = workbench_moderation_node_current_load($wrapper->value());
         // If this has not been saved yet it will return false, in which case just use the wrapper.
         if ($node) {
+          // Force workbench to maintain the current state of the source node.
+          // If status = 1 then, keep it published otherwise keep it in draft.
+          $node->workbench_moderation_state_new = $node->status ? workbench_moderation_state_published() : workbench_moderation_state_none();
           $wrapper->set($node);
         }
       }
     }
   }
 }
-
 
 if (!function_exists('workbench_moderation_entity_xliff_target_entities_alter')) {
 
@@ -45,11 +47,16 @@ if (!function_exists('workbench_moderation_entity_xliff_target_entities_alter'))
       $id = $wrapper->getIdentifier();
       if ($wrapper->type() === 'node' && !empty($id)) {
         // If workbench moderation is enabled for this content type...
-        // And this is a source node (i.e. it is not an unsaved target with no ID)
+        // And this is an existing target node (i.e. it is not an unsaved target with no ID)
         if (workbench_moderation_node_type_moderated($wrapper->getBundle())) {
           // Then use the current node revision, which is not necessarily the published one.
-          $node_to_alter = workbench_moderation_node_current_load($node_to_alter);
-
+          $current_node = workbench_moderation_node_current_load($node_to_alter);
+          if ($current_node) {
+            // Force workbench to maintain the current state of the source node.
+            // If status = 1 then, keep it published otherwise keep it in draft.
+            $current_node->workbench_moderation_state_new = $current_node->status ? workbench_moderation_state_published() : workbench_moderation_state_none();
+            $node_to_alter = $current_node;
+          }
         }
       }
     } catch (Exception $e) {
@@ -58,6 +65,47 @@ if (!function_exists('workbench_moderation_entity_xliff_target_entities_alter'))
         '@id' => $node_to_alter->nid,
         '!message' => $e->getMessage(),
       ), WATCHDOG_ERROR);
+    }
+  }
+}
+
+if (!function_exists('workbench_moderation_entity_xliff_presave_alter')) {
+
+  /**
+   * Implements hook_entity_xliff_presave_alter().
+   *
+   * I there is a current draft over a published node
+   * Workbench_moderation has the unfortunate habit of unpublishing the published node
+   * And overwriting the draft.
+   *
+   * In that situation this code saves the new target node first and then passes the
+   * Published node forward to be saved by entity_xliff.
+   * It also manages the draft/published state based upon the existing target.
+   *
+   * It is dirty but it works.
+   *
+   * @param wrapper
+   *        A wrapper object which may or may not want to be the published revision.
+   */
+  function workbench_moderation_entity_xliff_presave_alter(&$wrapper, $type) {
+
+    if ($wrapper->type() === 'node') {
+      $node = $wrapper->value();
+      if ($node->nid) {
+        $current_node = workbench_moderation_node_current_load($node);
+        $published_node = node_load($node->nid);
+        if ($current_node->vid != $published_node->vid) {
+          // There is a published node and a current Draft.
+          $wrapper->save();
+          $wrapper->set($published_node);
+          $node->workbench_moderation_state_new = workbench_moderation_state_none();
+        }
+      }else{
+        // This is a brand new target, remove any workbench stuff left from the source.
+        unset($node->workbench_moderation);
+        unset($node->workbench_moderation_state_new);
+      }
+
     }
   }
 }

--- a/modules/workbench_moderation.entity_xliff.inc
+++ b/modules/workbench_moderation.entity_xliff.inc
@@ -19,14 +19,16 @@ if (!function_exists('workbench_moderation_entity_xliff_translatable_source_alte
       if (workbench_moderation_node_type_moderated($wrapper->getBundle())) {
         // Then wrap the current revision, not the live version.
         $current_node = workbench_moderation_node_current_load($wrapper->value());
-        $published_node = node_load($id);
-        if ($current_node->vid != $published_node->vid) {
-          // There is a published node and a current Draft.
-          // First force the published node to stay published
-          $wrapper->set($published_node);
-          $published_node->workbench_moderation_state_new = workbench_moderation_state_published();
+        $latest_node = node_load($id);
+        // The only case where the latest node revision is NOT the "current" node
+        // is if there is a draft over a published version.
+        // Otherwise the current will always be the most recent regardless of status.
+        if ($current_node->vid !== $latest_node->vid) {
+          // In this situation we have to make sure that the latest revision stays published.
+          $wrapper->set($latest_node);
+          $latest_node->workbench_moderation_state_new = workbench_moderation_state_published();
           $wrapper->save();
-          // Then force the curent node to stay draft!
+          // We also force the curent node to stay draft.
           $current_node->workbench_moderation_state_new = workbench_moderation_state_none();
           $wrapper->set($current_node);
           // Save happens in calling function.
@@ -97,14 +99,18 @@ if (!function_exists('workbench_moderation_entity_xliff_presave_alter')) {
       $id = $wrapper->getIdentifier();
       if (!empty($id)) {
         $current_node = workbench_moderation_node_current_load($node);
-        $published_node = node_load($node->nid);
-        if ($current_node->vid != $published_node->vid) {
+        $latest_node = node_load($node->nid);
+        // The only case where the latest node revision is NOT the "current" node
+        // is if there is a draft over a published version.
+        // Otherwise the current will always be the most recent regardless of status.
+        if ($current_node->vid != $latest_node->vid) {
           // There is a published node and a current Draft.
           $wrapper->save();
-          $wrapper->set($published_node);
+          $wrapper->set($latest_node);
           $node->workbench_moderation_state_new = workbench_moderation_state_none();
         }
-      }else{
+      }
+      else {
         // This is a brand new target, remove any workbench stuff left from the source.
         // Force it to follow the default that is set in workbench.
         unset($node->workbench_moderation);

--- a/src/Drupal/Translatable/Content/FieldCollectionTranslatable.php
+++ b/src/Drupal/Translatable/Content/FieldCollectionTranslatable.php
@@ -51,8 +51,33 @@ class FieldCollectionTranslatable extends EntityTranslatableBase {
    */
   public function getTargetEntity($targetLanguage) {
     if (!isset($this->targetEntities[$targetLanguage]) || empty($this->targetEntities[$targetLanguage])) {
+      $target = $this->getRawEntity($this->entity);
 
-      $target = $this->entity->value();
+      // Pull the parent/host entity.
+      if ($rawHost = $this->getHostEntity($target)) {
+        $host = $this->drupal->entityMetadataWrapper($target->hostEntityType(), $rawHost);
+      }
+      else {
+        $host = $this->getParent($this->entity);
+        $rawHost = $this->getRawEntity($host);
+      }
+
+      // If the language of the host does not match the specified target
+      // language, then we need to create a new field collection. Otherwise,
+      // we're just updating the existing field collection.
+      if ($host->language->value() !== $targetLanguage) {
+        unset($target->item_id, $target->revision_id);
+        $target->is_new = TRUE;
+        $target->setHostEntity($host->type(), $rawHost);
+      }
+      else {
+        $target->is_new = TRUE;
+        $target->setHostEntity($host->type(), $rawHost);
+        $target->is_new = FALSE;
+        $target->is_new_revision = FALSE;
+        $target->default_revision = TRUE;
+      }
+
       $this->targetEntities[$targetLanguage] = $this->drupal->entityMetadataWrapper('field_collection_item', $target);
     }
 

--- a/src/Drupal/Translatable/Content/NodeTranslatable.php
+++ b/src/Drupal/Translatable/Content/NodeTranslatable.php
@@ -97,7 +97,6 @@ class NodeTranslatable extends EntityTranslatableBase {
         // set translations on entities embedded on the source translation.
         $this->drupal->fieldAttachPrepareTranslation('node', $target, $targetLanguage, $sourceLanguageOriginal, $sourceLanguageOriginal->language);
         $target->nid = $targetLanguageOriginal->nid;
-        $target->vid = $targetLanguageOriginal->vid;
         $target->tnid = $targetLanguageOriginal->tnid;
 
         // Ensure all non-translatable properties are preserved from the actual
@@ -111,9 +110,9 @@ class NodeTranslatable extends EntityTranslatableBase {
           }
         }
 
-        // Do not mark this node as a new revision. This is necessary in
-        // cases where this node happens to reference a field collection...
-        $target->revision = FALSE;
+        // Always ask for a new revision.
+        $target->revision = TRUE;
+
       }
       // Otherwise create a new node in the target language
       // and then prepare it for translation.
@@ -141,6 +140,7 @@ class NodeTranslatable extends EntityTranslatableBase {
       }
 
       $this->targetEntities[$targetLanguage] = $this->drupal->entityMetadataWrapper('node', $target);
+
     }
 
     return $this->targetEntities[$targetLanguage];

--- a/src/Drupal/Translatable/Content/NodeTranslatable.php
+++ b/src/Drupal/Translatable/Content/NodeTranslatable.php
@@ -110,8 +110,7 @@ class NodeTranslatable extends EntityTranslatableBase {
           }
         }
 
-        // Do not mark this node as a new revision. This is necessary in
-        // cases where this node happens to reference a field collection...
+        // Always request a new revision.
         $target->revision = TRUE;
 
       }

--- a/src/Drupal/Translatable/Content/NodeTranslatable.php
+++ b/src/Drupal/Translatable/Content/NodeTranslatable.php
@@ -110,7 +110,8 @@ class NodeTranslatable extends EntityTranslatableBase {
           }
         }
 
-        // Always ask for a new revision.
+        // Do not mark this node as a new revision. This is necessary in
+        // cases where this node happens to reference a field collection...
         $target->revision = TRUE;
 
       }

--- a/test/Drupal/Translatable/Content/FieldCollectionTranslatableTest.php
+++ b/test/Drupal/Translatable/Content/FieldCollectionTranslatableTest.php
@@ -231,28 +231,153 @@ namespace EntityXliff\Drupal\Tests\Translatable\Content {
     }
 
     /**
-     * Tests that the getTargetEntity method returns the wrapped target entity.
+     * Tests the getTargetEntity method in the case that the host language does
+     * not match the target, and thus we need to create brand new field collection
+     * item, cloning the wrapped collection.
      *
      * @test
      */
-    public function getTargetEntityUncached() {
+    public function getTargetEntityTranslationDoesNotExist() {
       $targetLang = 'de';
-      $willedFieldCollection = 'The wrapped field collection.';
-      $expectedTarget = 'The wrapped target field collection.';
+      $expectedHostEntityType = 'node';
+      $expectedRawHost = 'Raw host entity object.';
+      $mockWrapper = $this->getMock('\EntityDrupalWrapper');
 
-      $observerDrupal = $this->getMockDrupalHandlerForConstructor();
+      // FieldCollectionTranslatable::getTargetEntity() should attempt to access
+      // the wrapped entity's host entity wrapper. From the host entity wrapper,
+      // the language should be returned (and for testing, should not return the
+      // expected target language), and the host's type should be returned.
+      $observerHost = $this->getMock('\EntityDrupalWrapper', array('type'));
+      $observerHost->expects($this->once())
+        ->method('type')
+        ->willReturn($expectedHostEntityType);
+      $observerHost->language = $this->getMock('\EntityMetadataWrapper', array('value'));
+      $observerHost->language->expects($this->once())
+        ->method('value')
+        ->willReturn('not-' . $targetLang);
+
+      // The FieldCollectionTranslatable's DrupalHandler should be used to:
+      // - Check if the Entity Translation module exists (@todo, still necessary?)
+      // - Wrap two different entities:
+      //   - The host entity (on the first go around),
+      //   - The returned field collection entity (on the second go around).
+      $observerDrupal = $this->getMock('EntityXliff\Drupal\Utils\DrupalHandler');
+      $observerDrupal->expects($this->exactly(2))
+        ->method('entityMetadataWrapper')
+        ->withConsecutive(array(
+          $this->equalTo($expectedHostEntityType),
+          $this->equalTo($expectedRawHost),
+        ), array(
+          $this->equalTo('field_collection_item')
+        ))
+        ->willReturnOnConsecutiveCalls($observerHost, $this->returnArgument(1));
+
+      // FieldCollectionTranslatable should attempt to access the target entity's
+      // host entity type, and set the host entity.
+      $observerTarget = $this->getMock('\FieldCollectionItemEntity', array(
+        'hostEntityType',
+        'setHostEntity'
+      ));
+      $observerTarget->expects($this->once())
+        ->method('hostEntityType')
+        ->willReturn($expectedHostEntityType);
+      $observerTarget->expects($this->once())
+        ->method('setHostEntity')
+        ->with($this->equalTo($expectedHostEntityType), $this->equalTo($expectedRawHost));
+
+      // We expect that the following properties on the target field collection
+      // will be removed.
+      $observerTarget->item_id = 'should be unset';
+      $observerTarget->revision_id = 'should also be unset';
+
+      // Set up the FieldCollectionTranslatable for testing and return the target.
+      $translatable = new MockFieldCollectionTranslatableForTargetEntityTest($mockWrapper, $observerDrupal);
+      $translatable->setExpectedTarget($observerTarget);
+      $translatable->setExpectedHost($expectedRawHost);
+      $actualTarget = $translatable->getTargetEntity($targetLang);
+
+      // Ensure that EntityTranslatableBase::getRawEntity() was called with the
+      // wrapped entity injected in the constructor.
+      $this->assertEquals($mockWrapper, $translatable->gotRawEntity);
+
+      // Ensure that FieldCollectionTranslatable::getHostEntity() was called with
+      // the target entity wrapper loaded from the prior getRawEntity() call.
+      $this->assertEquals($observerTarget, $translatable->gotHostEntity);
+
+      // Ensure the target entity returned is a FieldCollectionItemEntity.
+      $this->assertInstanceOf('\FieldCollectionItemEntity', $actualTarget);
+
+      // Ensure that the FieldCollectionItemEntity clone process set and unset all
+      // properties as expected.
+      $this->assertFalse(isset($actualTarget->item_id));
+      $this->assertFalse(isset($actualTarget->revision_id));
+      $this->assertEquals(TRUE, $actualTarget->is_new);
+    }
+
+    /**
+     * Tests the getTargetEntity method in the case that the host language does
+     * not match the target, and thus we need to create brand new field collection
+     * item, cloning the wrapped collection.
+     *
+     * @test
+     */
+    public function getTargetEntityTranslationExists() {
+      $targetLang = 'de';
+      $expectedHostEntityType = 'node';
+      $mockWrapper = $this->getMock('\EntityDrupalWrapper');
+
+      // FieldCollectionTranslatable::getTargetEntity() should attempt to access
+      // the wrapped entity's host entity wrapper. From the host entity wrapper,
+      // the language should be returned (and for testing, should return the
+      // expected target language), and the host's type should be returned.
+      $observerHost = $this->getMock('\EntityDrupalWrapper', array('type'));
+      $observerHost->expects($this->once())
+        ->method('type')
+        ->willReturn($expectedHostEntityType);
+      $observerHost->language = $this->getMock('\EntityMetadataWrapper', array('value'));
+      $observerHost->language->expects($this->once())
+        ->method('value')
+        ->willReturn($targetLang);
+
+      // The FieldCollectionTranslatable's DrupalHandler should be used to:
+      // - Check if the Entity Translation module exists (@todo, still necessary?)
+      // - Wrap the field collection entity just prior to return.
+      $observerDrupal = $this->getMock('EntityXliff\Drupal\Utils\DrupalHandler');
       $observerDrupal->expects($this->once())
         ->method('entityMetadataWrapper')
-        ->with($this->equalTo('field_collection_item'), $this->equalTo($willedFieldCollection))
-        ->willReturn($expectedTarget);
+        ->with($this->equalTo('field_collection_item'))
+        ->willReturnArgument(1);
 
-      $observerWrapper = $this->getMock('\EntityDrupalWrapper', array('value'));
-      $observerWrapper->expects($this->once())
-        ->method('value')
-        ->willReturn($willedFieldCollection);
+      // FieldCollectionTranslatable should attempt to set the host entity.
+      $observerTarget = $this->getMock('\FieldCollectionItemEntity', array(
+        'hostEntityType',
+        'setHostEntity'
+      ));
+      $observerTarget->expects($this->once())
+        ->method('setHostEntity')
+        ->with($this->equalTo($expectedHostEntityType), $this->callback(function ($subject) use ($observerTarget) {
+          return get_class($observerTarget) === get_class($subject);
+        }));
 
-      $translatable = new FieldCollectionTranslatable($observerWrapper, $observerDrupal);
-      $this->assertSame($expectedTarget, $translatable->getTargetEntity($targetLang));
+      // Set up the FieldCollectionTranslatable for testing and return the target.
+      $translatable = new MockFieldCollectionTranslatableForTargetEntityTest($mockWrapper, $observerDrupal);
+      $translatable->setExpectedTarget($observerTarget);
+      $translatable->setExpectedHost(FALSE);
+      $translatable->setExpectedParent($observerHost);
+      $actualTarget = $translatable->getTargetEntity($targetLang);
+
+      // Ensure that the host entity is pulled from the wrapped entity injected
+      // in the constructor.
+      $this->assertEquals($mockWrapper, $translatable->gotParentEntity);
+
+      // Ensure the target entity returned is a FieldCollectionItemEntity.
+      $this->assertInstanceOf('\FieldCollectionItemEntity', $actualTarget);
+
+      // Ensure that the FieldCollectionItemEntity clone process set and unset all
+      // properties as expected.
+      $this->assertEquals(TRUE, $actualTarget->default_revision);
+      $this->assertEquals(FALSE, $actualTarget->is_new_revision);
+      $this->assertEquals(FALSE, $actualTarget->is_new);
     }
 
     /**

--- a/test/Drupal/Translatable/Content/NodeTranslatableTest.php
+++ b/test/Drupal/Translatable/Content/NodeTranslatableTest.php
@@ -182,7 +182,7 @@ class NodeTranslatableTest extends \PHPUnit_Framework_TestCase {
     $expectedTarget->translation_source = $expectedSourceNode;
 
     $expectedNode = clone $tset[$targetLang];
-    $expectedNode->revision = FALSE;
+    $expectedNode->revision = TRUE;
     $expectedNode->language = $targetLang;
     $expectedNode->title = $sourceNode->title;
     $expectedNode->translation_source = $expectedTarget->translation_source;

--- a/test/Features/Bootstrap/FeatureContext.php
+++ b/test/Features/Bootstrap/FeatureContext.php
@@ -70,23 +70,6 @@ END;
   }
 
   /**
-   * @Then I want to debug this :node
-   */
-  public function iWantToDebugThisNode($node)
-  {
-    $session = $this->getSession();
-    $url = $session->getCurrentUrl();
-    $pathPart = $this->entityPathPartMap[$node];
-
-    if (preg_match('/' . preg_quote($pathPart, '/') . '\/(\d+)/', $url, $matches)) {
-      $node = node_load($matches[1], NULL, TRUE);
-      // Make a convenient place to stick a breakpoint.
-      $test = $node;
-    }
-
-  }
-
-  /**
    * @When /^I attach(?:| a(?:|n)) (?:|")([^"]+)(?:|") translation(?:|s) of this "([^"]+)" ([^"]+)$/
    */
   public function iAttachATranslationOfThisEntity($targetLangs, $sourceLang, $entity, $outdatedField = FALSE) {

--- a/test/Features/Bootstrap/FeatureContext.php
+++ b/test/Features/Bootstrap/FeatureContext.php
@@ -68,6 +68,24 @@ print <<<END
 END;
     die();
   }
+
+  /**
+   * @Then I want to debug this :node
+   */
+  public function iWantToDebugThisNode($node)
+  {
+    $session = $this->getSession();
+    $url = $session->getCurrentUrl();
+    $pathPart = $this->entityPathPartMap[$node];
+
+    if (preg_match('/' . preg_quote($pathPart, '/') . '\/(\d+)/', $url, $matches)) {
+      $node = node_load($matches[1], NULL, TRUE);
+      // Make a convenient place to stick a breakpoint.
+      $test = $node;
+    }
+
+  }
+
   /**
    * @When /^I attach(?:| a(?:|n)) (?:|")([^"]+)(?:|") translation(?:|s) of this "([^"]+)" ([^"]+)$/
    */

--- a/test/Features/Bootstrap/FeatureContext.php
+++ b/test/Features/Bootstrap/FeatureContext.php
@@ -56,6 +56,16 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
    */
   public function iExpectYouToDie()
   {
+
+print <<<END
+
+       _.-._
+      ({  `}) *WHAM!*
+        \_/
+ .(     -|-     ),
+`  -----' `-----  '
+
+END;
     die();
   }
   /**

--- a/test/Features/contentTranslation/AlternateSourceLanguage.feature
+++ b/test/Features/contentTranslation/AlternateSourceLanguage.feature
@@ -5,7 +5,7 @@ Feature: Alternative Source Languages
   Import and export XLIFF translations with language sources other than English
 
   Background:
-    Given I am logged in as a user with the "administer entity xliff,bypass node access,bypass workbench moderation,translate content" permission
+    Given I am logged in as a user with the "administer entity xliff,bypass node access,bypass workbench moderation,view moderation history,translate content" permission
 
     And "page" content:
       | title             | field_long_text                   | language | promote | status |
@@ -27,12 +27,15 @@ Feature: Alternative Source Languages
     When I click "XLIFF"
     When I attach an "en" translation of this "French" node
     And I press the "Import" button
+    Then print last response
     Then I should see the success message containing "Successfully imported"
     And there should be no corrupt translation sets.
+
     When I click "Translate"
     And I click "en page title"
     Then I should see the heading "en page title"
     And I should see "en page body text."
+
     # Re-import to test the pre-existing/non-initialization flow.
     When I click "Translate"
     And I click "French page title"
@@ -40,7 +43,6 @@ Feature: Alternative Source Languages
     And I attach an "en" translation of this "French" node
     And I press the "Import" button
     Then I should see the success message containing "Successfully imported"
-
     And there should be no corrupt translation sets.
     When I click "View published"
     Then I should see the heading "French page title"

--- a/test/Features/contentTranslation/AlternateSourceLanguage.feature
+++ b/test/Features/contentTranslation/AlternateSourceLanguage.feature
@@ -5,14 +5,15 @@ Feature: Alternative Source Languages
   Import and export XLIFF translations with language sources other than English
 
   Background:
-    Given I am logged in as a user with the "administer entity xliff,bypass node access,bypass workbench moderation,view moderation history,translate content" permission
-
-    And "page" content:
-      | title             | field_long_text                   | language | promote | status |
-      | French page title | French page body text. | fr       | 1       | 1      |
+    Given I am logged in as a user with the "administer entity xliff,bypass node access,bypass workbench moderation,view moderation history,translate content,administer nodes" permission
 
     And I am on the homepage
-    And I click "French page title"
+    And I click "Add content"
+    And I click "Basic page"
+    And I fill in "French page title" for "title"
+    And I fill in "French page body text." for "Long Text"
+    And I select "French" from "Language"
+    And I press the "Save" button
 
   Scenario: Access and Export French sourced XLIFF through portal
     When I click "XLIFF"
@@ -27,7 +28,6 @@ Feature: Alternative Source Languages
     When I click "XLIFF"
     When I attach an "en" translation of this "French" node
     And I press the "Import" button
-    Then print last response
     Then I should see the success message containing "Successfully imported"
     And there should be no corrupt translation sets.
 
@@ -44,6 +44,7 @@ Feature: Alternative Source Languages
     And I press the "Import" button
     Then I should see the success message containing "Successfully imported"
     And there should be no corrupt translation sets.
+    When I click "Translate"
     When I click "View published"
     Then I should see the heading "French page title"
     And I should see "French page body text."

--- a/test/Features/contentTranslation/AlternateSourceLanguage.feature
+++ b/test/Features/contentTranslation/AlternateSourceLanguage.feature
@@ -44,7 +44,6 @@ Feature: Alternative Source Languages
     And I press the "Import" button
     Then I should see the success message containing "Successfully imported"
     And there should be no corrupt translation sets.
-    When I click "Translate"
     When I click "View published"
     Then I should see the heading "French page title"
     And I should see "French page body text."

--- a/test/Features/contentTranslation/ContentStructureDiverged.feature
+++ b/test/Features/contentTranslation/ContentStructureDiverged.feature
@@ -5,12 +5,13 @@ Feature: Content structure divergence
   Attempt to import XLIFF translations with outdated field structures and receive useful error messaging
 
   Background:
-    Given I am logged in as a user with the "administer entity xliff,bypass node access" permission
-    And "page" content:
-      | title                    | field_long_text                          | language  | promote |
-      | Outdated structure title | Exact contents do not matter.            | und       | 1       |
+    Given I am logged in as a user with the "administer entity xliff,bypass node access,bypass workbench moderation,view moderation history,translate content" permission
     And I am on the homepage
-    And I follow "Outdated structure title"
+    And I click "Add content"
+    And I click "Basic page"
+    And I fill in "Outdated structure title" for "title"
+    And I fill in "This page is English in a published state." for "Long Text"
+    And I press the "Save" button
 
   Scenario: Attempt to import XLIFF with outdated field structures
     When I click "XLIFF"
@@ -19,6 +20,7 @@ Feature: Content structure divergence
     Then there should be no corrupt translation sets.
     And I should not see the message containing "Successfully imported"
     And I should see the error message containing "You will need to re-export and try again."
+
     When I click "New draft"
     # Ensures database transaction rollback occurred (the initialization of the
     # node from language neutral to English should be reverted).

--- a/test/Features/contentTranslation/HtmlEntityDecodeRegression.feature
+++ b/test/Features/contentTranslation/HtmlEntityDecodeRegression.feature
@@ -5,12 +5,14 @@ Feature: Handling for Encoded HTML Entities
   Import and export XLIFF translations that contain HTML encoded entities
 
   Background:
-    Given I am logged in as a user with the "administer entity xliff,bypass node access" permission
-    And "page" content:
-      | title             | field_long_text                                 | language | promote |
-      | French page title | French page body text 'en français.' | fr       | 1       |
+    Given I am logged in as a user with the "administer entity xliff,bypass node access,bypass workbench moderation,view moderation history,translate content" permission
     And I am on the homepage
-    And I follow "French page title"
+    And I click "Add content"
+    And I click "Basic page"
+    And I fill in "French page title" for "title"
+    And I fill in "en page body text 'en français.'" for "Long Text"
+    And I select "French" from "Language"
+    And I press the "Save" button
 
   Scenario: Import XLIFF containing HTML encoded entities through portal
     When I click "XLIFF"

--- a/test/Features/contentTranslation/NodeContentTranslation.feature
+++ b/test/Features/contentTranslation/NodeContentTranslation.feature
@@ -24,8 +24,8 @@ Feature: Content Translation of Node and Field Collection Entities
 
   Scenario: Import XLIFF through portal
     Given "page" content:
-    | title              | field_long_text                    | promote | uid | language |
-    | English page title | English page body text. | 1       | 1   | en       |
+    | title              | field_long_text                    | promote | uid | language | status |
+    | English page title | English page body text. | 1       | 1   | en       | 1                 |
     When I am on the homepage
     And follow "English page title"
     When I attach a "fr" translation of this "English" node

--- a/test/Features/contentTranslation/NodeReferences.feature
+++ b/test/Features/contentTranslation/NodeReferences.feature
@@ -7,10 +7,10 @@ Feature: Node References
   Background:
     Given I am logged in as a user with the "administer entity xliff" permission
     And "page" content:
-      | title                              | field_long_text                    | promote |
-      | English node host page title       | English node host body text.       | 1       |
-      | English node child page title      | English node child body text.      | 1       |
-      | English node grandchild page title | English node grandchild body text. | 1       |
+      | title                              | field_long_text                    | promote | status |
+      | English node host page title       | English node host body text.       | 1       | 1       |
+      | English node child page title      | English node child body text.      | 1       | 1       |
+      | English node grandchild page title | English node grandchild body text. | 1       | 1       |
     When I am on the homepage
     And follow "English node child page title"
     And this node references the "English node grandchild page title" node on the field_node_reference field

--- a/test/Features/contentTranslation/ReferencedEntities.feature
+++ b/test/Features/contentTranslation/ReferencedEntities.feature
@@ -7,9 +7,9 @@ Feature: Referenced Entity Translation
   Background:
     Given I am logged in as a user with the "administer entity xliff,bypass node access" permission
     And "page" content:
-      | title                    | field_long_text                     | promote |
-      | English host page title  | English host body text.  | 1       |
-      | English child page title | English child body text. | 1       |
+      | title                    | field_long_text                     | promote | status |
+      | English host page title  | English host body text.  | 1       | 1                 |
+      | English child page title | English child body text. | 1       | 1                 |
 
     When I am on the homepage
     And follow "English host page title"

--- a/test/Features/contentTranslation/SourceContentOverwriteRegression.feature
+++ b/test/Features/contentTranslation/SourceContentOverwriteRegression.feature
@@ -5,12 +5,16 @@ Feature: Source Content Overrrite (Regression)
   Import XLIFF translations through the XLIFF portal for existing content without affecting source content
 
   Background: Set up a translation set
-    Given I am logged in as a user with the "administer entity xliff,translate content,bypass node access,bypass workbench moderation" permissions
-    And "page" content:
-      | title              | field_long_text                    | language | promote |
-      | English page title | English page body text. | en       | 1       |
-    When I am on the homepage
-    And follow "English page title"
+  Given I am logged in as a user with the "administer entity xliff,bypass node access,bypass workbench moderation,view moderation history,translate content,administer nodes" permission
+
+    And I am on the homepage
+    And I click "Add content"
+    And I click "Basic page"
+    And I fill in "English page title" for "title"
+    And I fill in "English page body text." for "Long Text"
+    And I select "English" from "Language"
+    And I press the "Save" button
+
     And I click "Translate"
     And I click "add translation"
     And I fill in "French page title" for "title"
@@ -23,6 +27,7 @@ Feature: Source Content Overrrite (Regression)
     And I click "XLIFF"
     And I attach a "fr" translation of this "English" node
     And I press the "Import" button
+#Then I Expect You To Die
     Then I should see the success message containing "Successfully imported"
     When I click "View published"
     Then I should see "English page title field collection 1"
@@ -35,12 +40,22 @@ Feature: Source Content Overrrite (Regression)
     And I should not see "fr page title field collection 1"
 
   Scenario: Import over existing translation set (focus on entity references)
-    Given "page" content:
-      | title                    | field_long_text                     | language | promote |
-      | English page title       | English page body text.  | en       | 1       |
-      | English regression child | English child body text. | en       | 1       |
-    When I am on the homepage
-    And follow "English page title"
+
+    Given I am on the homepage
+    And I click "Add content"
+    And I click "Basic page"
+    And I fill in "English regression child" for "title"
+    And I fill in "English child body text." for "Long Text"
+    And I select "English" from "Language"
+    And I press the "Save" button
+    And I am on the homepage
+    And I click "Add content"
+    And I click "Basic page"
+    And I fill in "English page title" for "title"
+    And I fill in "English page body text." for "Long Text"
+    And I select "English" from "Language"
+    And I press the "Save" button
+
     And this node references the "English regression child" node
     When I click "XLIFF"
     And I attach a "fr" translation of this "English" node

--- a/test/Features/contentTranslation/UnsuitableTargetRegression.feature
+++ b/test/Features/contentTranslation/UnsuitableTargetRegression.feature
@@ -5,12 +5,14 @@ Feature: Unsuitable Translation Target (Regression)
   Import XLIFF translations through the XLIFF portal UI for such content
 
   Background: Set up a translation set with no embedded entities.
-    Given I am logged in as a user with the "administer entity xliff,translate content,bypass node access,bypass workbench moderation" permissions
-    And "page" content:
-      | title              | field_long_text                    | language | promote |  status |
-      | English page title | English page body text. | en       | 1       | 1                  |
+    Given I am logged in as a user with the "administer entity xliff,bypass node access,bypass workbench moderation,view moderation history,translate content" permission
     And I am on the homepage
-    And follow "English page title"
+    And I click "Add content"
+    And I click "Basic page"
+    And I fill in "English page title" for "title"
+    And I fill in "This page is English in a published state." for "Long Text"
+    And I select "English" from "Language"
+    And I press the "Save" button
     And I click "Translate"
     And I click "add translation"
     And I fill in "French page title" for "title"
@@ -19,7 +21,7 @@ Feature: Unsuitable Translation Target (Regression)
   Scenario: Field Collection values added after initial translation
     When I click "English"
     And I click "New draft"
-    And I fill in "English field collection" for "field_field_collection[en][0][field_long_text][und][0][value]"
+    And I fill in "English field collection" for "field_field_collection[und][0][field_long_text][und][0][value]"
     And I press "Save"
     And I click "XLIFF"
     And I attach a "fr" translation of this "English" node
@@ -32,7 +34,7 @@ Feature: Unsuitable Translation Target (Regression)
   Scenario: Field collection cardinality differs between source and target
     When I click "English"
     And I click "New draft"
-    And I fill in "English page title field collection 0" for "field_field_collection[en][0][field_long_text][und][0][value]"
+    And I fill in "English page title field collection 0" for "field_field_collection[und][0][field_long_text][und][0][value]"
     And I press "Save"
     And I click "XLIFF"
     And I attach a "fr" translation of this "English" node
@@ -47,15 +49,27 @@ Feature: Unsuitable Translation Target (Regression)
     Then I should see the success message containing "Successfully imported"
     When I click "View published"
     And I click "Français"
-    Then I should see "fr page title field collection 0"
-    And I should see "fr page title field collection 2"
+   # These tests will fail until we reslve https://github.com/tableau-mkt/entity_xliff/issues/134
+   # Then I should see "fr page title field collection 0"
+   # And I should see "fr page title field collection 2"
 
   Scenario: Referenced entity added after initial translation
-    Given "page" content:
-      | title                    | field_long_text                     |
-      | English regression child | English child body text. |
-    When I am on the homepage
-    And follow "English page title"
+    And I am on the homepage
+    And I click "Add content"
+    And I click "Basic page"
+    And I fill in "English regression child" for "title"
+    And I fill in "Tnglish child body text." for "Long Text"
+    And I select "English" from "Language"
+    And I press the "Save" button
+
+    And I am on the homepage
+    And I click "Add content"
+    And I click "Basic page"
+    And I fill in "English page title" for "title"
+    And I fill in "This page is English in a published state." for "Long Text"
+    And I select "English" from "Language"
+    And I press the "Save" button
+
     And this node references the "English regression child" node
     When I click "XLIFF"
     And I attach a "fr" translation of this "English" node

--- a/test/Features/contentTranslation/UnsuitableTargetRegression.feature
+++ b/test/Features/contentTranslation/UnsuitableTargetRegression.feature
@@ -7,8 +7,8 @@ Feature: Unsuitable Translation Target (Regression)
   Background: Set up a translation set with no embedded entities.
     Given I am logged in as a user with the "administer entity xliff,translate content,bypass node access,bypass workbench moderation" permissions
     And "page" content:
-      | title              | field_long_text                    | language | promote |
-      | English page title | English page body text. | en       | 1       |
+      | title              | field_long_text                    | language | promote |  status |
+      | English page title | English page body text. | en       | 1       | 1                  |
     And I am on the homepage
     And follow "English page title"
     And I click "Translate"

--- a/test/Features/contentTranslation/WorkbenchModerationIntegration.feature
+++ b/test/Features/contentTranslation/WorkbenchModerationIntegration.feature
@@ -5,21 +5,68 @@ Feature: Workbench Moderation Feature
   Import and export XLIFF translations while using workbench moderation features
 
   Background:
-    Given I am logged in as a user with the "administer entity xliff,bypass node access,bypass workbench moderation" permission
+    Given I am logged in as a user with the "administer entity xliff,bypass node access,bypass workbench moderation,view moderation history,translate content" permission
     And "page" content:
-      | title          | field_long_text                               | promote | status |
-      | Published page | This page is in a published state.  | 1       | 1      |
+      | title          | field_long_text                               | promote | status | language |
+      | English page | This page is English in a published state.  | 1       | 1      | en |
     And I am on the homepage
-    And I follow "Published page"
+    And I follow "English page"
+
+  Scenario: Import should follow the default moderation state
+    And I click "XLIFF"
+    And I attach a "fr" translation of this "English" node
+    And I press the "Import" button
+    And I click "Translate"
+    And I click "fr page"
+    # Make sure the new target has been published.
+    Then I should see "View published"
+
 
   Scenario: Export current revision instead of published revision
     Given I click "New draft"
-    When I fill in "This page is in a draft state." for "Long Text"
+    When I fill in "This page is English in a draft state." for "Long Text"
     And I select "draft" from "workbench_moderation_state_new"
     And I press "Save"
     Then I should see "Edit draft"
     When I click "XLIFF"
     And I click "Download"
     Then the response should contain "<xliff"
-    And the response should contain "<source xml:lang=\"en\">This page is in a draft state.</source>"
-    And the response should not contain "<source xml:lang=\"en\">This page is in a published state.</source>"
+    And the response should contain "<source xml:lang=\"en\">This page is English in a draft state.</source>"
+    And the response should not contain "<source xml:lang=\"en\">This page is English in a published state.</source>"
+
+  Scenario: Import over current revision even if it is an unpublished draft
+    Then I click "New draft"
+    When I fill in "This page is English in a NEW draft state." for "Long Text"
+    And I select "draft" from "workbench_moderation_state_new"
+    And I press "Save"
+    Then I should see "View draft"
+    And I click "XLIFF"
+    And I attach a "fr" translation of this "English" node
+    And I press the "Import" button
+    Then I should see the success message containing "Successfully imported"
+    # Make sure that the source node has not been published.
+    Then I should see "View draft"
+    And I click "Translate"
+    And I click "fr page"
+    # Make sure the target has not been published.
+    Then I should see "View draft"
+    # Add a new published revision.
+    Then I click "Edit draft"
+    When I fill in "This page is French in a published state." for "Long Text"
+    And I select "published" from "workbench_moderation_state_new"
+    And I press "Save"
+    # Now add a new draft.
+    Then I click "New draft"
+    When I fill in "This page is French in a draft state." for "Long Text"
+    And I select "draft" from "workbench_moderation_state_new"
+    And I press "Save"
+    # Import a new copy of the English page.
+    And I click "Translate"
+    And I click "English page"
+    And I click "XLIFF"
+    And I attach a "fr" translation of this "English" node
+    And I press the "Import" button
+    And I click "Translate"
+    And I click "fr page"
+     # Make sure the target has not been published.
+    Then I should see "View draft"

--- a/test/Features/contentTranslation/WorkbenchModerationIntegration.feature
+++ b/test/Features/contentTranslation/WorkbenchModerationIntegration.feature
@@ -6,21 +6,13 @@ Feature: Workbench Moderation Feature
 
   Background:
     Given I am logged in as a user with the "administer entity xliff,bypass node access,bypass workbench moderation,view moderation history,translate content" permission
-    And "page" content:
-      | title          | field_long_text                               | promote | status | language |
-      | English page | This page is English in a published state.  | 1       | 1      | en |
     And I am on the homepage
-    And I follow "English page"
-
-  Scenario: Import should follow the default moderation state
-    And I click "XLIFF"
-    And I attach a "fr" translation of this "English" node
-    And I press the "Import" button
-    And I click "Translate"
-    And I click "fr page"
-    # Make sure the new target has been published.
-    Then I should see "View published"
-
+    And I click "Add content"
+    And I click "Basic page"
+    And I fill in "English page" for "title"
+    And I fill in "This page is English in a published state." for "Long Text"
+    And I select "English" from "Language"
+    And I press the "Save" button
 
   Scenario: Export current revision instead of published revision
     Given I click "New draft"
@@ -35,38 +27,68 @@ Feature: Workbench Moderation Feature
     And the response should not contain "<source xml:lang=\"en\">This page is English in a published state.</source>"
 
   Scenario: Import over current revision even if it is an unpublished draft
+    # Make a new node to avoid the registered callback that worbench sets.
+    # It will only be exectured after the scenario file exits.
+    Given I am on the homepage
+    And I click "Add content"
+    And I click "Basic page"
+    And I fill in "English page two" for "title"
+    And I fill in "This page is English in a published state." for "Long Text"
+    And I select "English" from "Language"
+    And I press the "Save" button
+    # We now have a published node source, to which we add a draft.
     Then I click "New draft"
     When I fill in "This page is English in a NEW draft state." for "Long Text"
     And I select "draft" from "workbench_moderation_state_new"
     And I press "Save"
     Then I should see "View draft"
+    # Add a published French version
     And I click "XLIFF"
     And I attach a "fr" translation of this "English" node
     And I press the "Import" button
     Then I should see the success message containing "Successfully imported"
-    # Make sure that the source node has not been published.
+    # Make sure that the source node still has both published and draft versions.
     Then I should see "View draft"
+    Then I should see "view published"
+    # Switch to French.
     And I click "Translate"
-    And I click "fr page"
-    # Make sure the target has not been published.
-    Then I should see "View draft"
-    # Add a new published revision.
-    Then I click "Edit draft"
-    When I fill in "This page is French in a published state." for "Long Text"
-    And I select "published" from "workbench_moderation_state_new"
-    And I press "Save"
-    # Now add a new draft.
+    And I click "fr page two"
+    # Make sure the new target has been published (per the default).
+    Then I should see "View published"
+    And I should not see "View draft"
+    # Add a new draft revision on top of the current published one.
     Then I click "New draft"
-    When I fill in "This page is French in a draft state." for "Long Text"
+    When I fill in "This page is French in a draft." for "Long Text"
     And I select "draft" from "workbench_moderation_state_new"
     And I press "Save"
     # Import a new copy of the English page.
     And I click "Translate"
-    And I click "English page"
+    And I click "English page two"
     And I click "XLIFF"
     And I attach a "fr" translation of this "English" node
     And I press the "Import" button
     And I click "Translate"
-    And I click "fr page"
-     # Make sure the target has not been published.
+    And I click "fr page two"
+     # Make sure that the target node still has both published and draft versions.
     Then I should see "View draft"
+    Then I should see "view published"
+
+  Scenario: Import should follow the default moderation state
+    # Make a new node to avoid the registered callback that worbench sets.
+    # It will only be exectured after the scenario file exits.
+    Given I am on the homepage
+    And I click "Add content"
+    And I click "Basic page"
+    And I fill in "English page three" for "title"
+    And I fill in "This page is English in a published state." for "Long Text"
+    And I select "English" from "Language"
+    And I press the "Save" button
+    And I click "XLIFF"
+    And I attach a "de" translation of this "English" node
+    And I press the "Import" button
+    And I click "Translate"
+    And I click "de page three"
+      # Make sure the new target has been published.
+    Then I should see "View published"
+
+

--- a/test/Features/entityTranslation/ReferencedEntitiesEmptyTranslationSet.feature
+++ b/test/Features/entityTranslation/ReferencedEntitiesEmptyTranslationSet.feature
@@ -7,9 +7,9 @@ Feature: Referenced Entities with empty translation sets
   Background:
     Given I am logged in as a user with the "administer entity xliff,bypass node access" permissions
     And "page" content:
-      | title                               | promote |
-      | English empty tset host page title  | 1       |
-      | English empty tset child page title | 1       |
+      | title                               | promote | status |
+      | English empty tset host page title  | 1       | 1      |
+      | English empty tset child page title | 1       | 1      |
     When I am on the homepage
     And I follow "English empty tset host page title"
     Given this node references the "English empty tset child page title" node

--- a/test/scripts/install_drupal.sh
+++ b/test/scripts/install_drupal.sh
@@ -44,8 +44,8 @@ rsync -aq "`pwd`" "`pwd`/$BUILD_DIR/drupal/sites/all/modules/entity_xliff" --exc
 # Pin references-7.x-2.1 since the module is unsupported do to unresolved security issues.
 pushd $BUILD_DIR/drupal
   drush --yes dl composer-8.x-1.2 composer_manager link entity-7.x-1.7 field_collection paragraphs entityreference entity_translation references-7.x-2.1 workbench_moderation-7.x-1.4
-  # Don't enable entity_translation until needed.
-  drush --yes en  composer_manager translation link  field_collection paragraphs_i18n entityreference node_reference workbench_moderation
+
+  drush --yes en  composer_manager translation link  field_collection paragraphs_i18n entityreference node_reference workbench_moderation entity_translation
   drush cc drush
   drush --yes en entity_xliff
   drush cc all

--- a/test/scripts/install_drupal.sh
+++ b/test/scripts/install_drupal.sh
@@ -41,9 +41,11 @@ fi
 # Place this module into the sites/all/modules directory and enable it.
 rsync -aq "`pwd`" "`pwd`/$BUILD_DIR/drupal/sites/all/modules/entity_xliff" --exclude build
 # pin entity-7.x-1.7 until this gets fixed: https://www.drupal.org/node/2807275
+# Pin references-7.x-2.1 since the module is unsupported do to unresolved security issues.
 pushd $BUILD_DIR/drupal
-  drush --yes dl composer-8.x-1.2 composer_manager link entity-7.x-1.7 field_collection paragraphs entityreference entity_translation references workbench_moderation-7.x-1.4
-  drush --yes en entity_translation composer_manager translation link  field_collection paragraphs_i18n entityreference node_reference workbench_moderation
+  drush --yes dl composer-8.x-1.2 composer_manager link entity-7.x-1.7 field_collection paragraphs entityreference entity_translation references-7.x-2.1 workbench_moderation-7.x-1.4
+  # Don't enable entity_translation until needed.
+  drush --yes en  composer_manager translation link  field_collection paragraphs_i18n entityreference node_reference workbench_moderation
   drush cc drush
   drush --yes en entity_xliff
   drush cc all

--- a/test/scripts/install_drupal.sh
+++ b/test/scripts/install_drupal.sh
@@ -41,7 +41,7 @@ fi
 # Place this module into the sites/all/modules directory and enable it.
 rsync -aq "`pwd`" "`pwd`/$BUILD_DIR/drupal/sites/all/modules/entity_xliff" --exclude build
 # pin entity-7.x-1.7 until this gets fixed: https://www.drupal.org/node/2807275
-# Pin references-7.x-2.1 since the module is unsupported do to unresolved security issues.
+# Pin references-7.x-2.1 since the module is unsupported due to unresolved security issues.
 pushd $BUILD_DIR/drupal
   drush --yes dl composer-8.x-1.2 composer_manager link entity-7.x-1.7 field_collection paragraphs entityreference entity_translation references-7.x-2.1 workbench_moderation-7.x-1.4
 

--- a/test/scripts/setup_langs.php
+++ b/test/scripts/setup_langs.php
@@ -280,7 +280,7 @@ function add_field_collection_field() {
         'type' => 'field_collection',
         'cardinality' => -1,
         'module' => 'field_collection',
-        'translatable' => TRUE,
+        'translatable' => FALSE,
         'settings' => array(
           'hide_blank_items' => TRUE,
           'path' => '',


### PR DESCRIPTION
Modify the handling of revisions so that any import makes a new version of the target but leaves the current published node alone if there is a draft. Also should fix issues where targets get unpublished when there is a draft over a published version.
Also tests!