### PR TITLE
In draft over pub paragraphs content was getting squashed.

### DIFF
--- a/modules/workbench_moderation.entity_xliff.inc
+++ b/modules/workbench_moderation.entity_xliff.inc
@@ -78,15 +78,11 @@ if (!function_exists('workbench_moderation_entity_xliff_presave_alter')) {
   /**
    * Implements hook_entity_xliff_presave_alter().
    *
-   * I there is a current draft over a published node
+   * If there is a current draft over a published node
    * Workbench_moderation has the unfortunate habit of unpublishing the published node
    * And overwriting the draft.
    *
-   * In that situation this code saves the new target node first and then passes the
-   * Published node forward to be saved by entity_xliff.
-   * It also manages the draft/published state based upon the existing target.
-   *
-   * It is dirty but it works.
+   * In that situation this code grabs the draft node to be saved by entity_xliff.
    *
    * @param wrapper
    *        A wrapper object which may or may not want to be the published revision.
@@ -105,9 +101,9 @@ if (!function_exists('workbench_moderation_entity_xliff_presave_alter')) {
         // Otherwise the current will always be the most recent regardless of status.
         if ($current_node->vid != $latest_node->vid) {
           // There is a published node and a current Draft.
-          $wrapper->save();
-          $wrapper->set($latest_node);
-          $node->workbench_moderation_state_new = workbench_moderation_state_none();
+          // Use the current (i.e. draft) node and keep it draft.
+          $wrapper->set($current_node);
+          $current_node->workbench_moderation_state_new = workbench_moderation_state_none();
         }
       }
       else {

--- a/test/Features/Bootstrap/FeatureContext.php
+++ b/test/Features/Bootstrap/FeatureContext.php
@@ -70,6 +70,13 @@ END;
   }
 
   /**
+   * @When I switch page default moderation To :state
+   */
+  public function iSwitchPageDefaultModerationTo($state) {
+    variable_set('workbench_moderation_default_state_page', $state);
+  }
+
+  /**
    * @When /^I attach(?:| a(?:|n)) (?:|")([^"]+)(?:|") translation(?:|s) of this "([^"]+)" ([^"]+)$/
    */
   public function iAttachATranslationOfThisEntity($targetLangs, $sourceLang, $entity, $outdatedField = FALSE) {

--- a/test/Features/Bootstrap/FeatureContext.php
+++ b/test/Features/Bootstrap/FeatureContext.php
@@ -70,9 +70,9 @@ END;
   }
 
   /**
-   * @When I switch page default moderation To :state
+   * @When I switch page default moderation to :state
    */
-  public function iSwitchPageDefaultModerationTo($state) {
+  public function iSwitchPageDefaultModerationto($state) {
     variable_set('workbench_moderation_default_state_page', $state);
   }
 

--- a/test/Features/contentTranslation/WorkbenchModerationIntegration.feature
+++ b/test/Features/contentTranslation/WorkbenchModerationIntegration.feature
@@ -33,15 +33,15 @@ Feature: Workbench Moderation Feature
     # Make a new node to avoid the registered callback that worbench sets.
     # It will only be exectured after the scenario file exits.
     Given I am on the homepage
-    And I click "Add content"
+    When I click "Add content"
     And I click "Basic page"
     And I fill in "English page two" for "title"
     And I fill in "This page is English in a published state." for "Long Text"
     And I select "English" from "Language"
     And I press the "Save" button
     # We now have a published node source, to which we add a draft.
-    Then I click "New draft"
-    When I fill in "This page is English in a NEW draft state." for "Long Text"
+    And I click "New draft"
+    And I fill in "This page is English in a NEW draft state." for "Long Text"
     And I select "draft" from "workbench_moderation_state_new"
     And I press "Save"
     Then I should see "View draft"
@@ -51,17 +51,17 @@ Feature: Workbench Moderation Feature
     And I press the "Import" button
     Then I should see the success message containing "Successfully imported"
     # Make sure that the source node still has both published and draft versions.
-    Then I should see "View draft"
-    Then I should see "view published"
+    And I should see "View draft"
+    And I should see "view published"
     # Switch to French.
-    And I click "Translate"
+    When I click "Translate"
     And I click "fr page two"
     # Make sure the new target has been published (per the default).
     Then I should see "View published"
     And I should not see "View draft"
     # Add a new draft revision on top of the current published one.
-    Then I click "New draft"
-    When I fill in "This page is French in a draft." for "Long Text"
+    When I click "New draft"
+    And I fill in "This page is French in a draft." for "Long Text"
     And I select "draft" from "workbench_moderation_state_new"
     And I press "Save"
     # Import a new copy of the English page.
@@ -72,11 +72,22 @@ Feature: Workbench Moderation Feature
     And I press the "Import" button
     And I click "Translate"
     And I click "fr page two"
-     # Make sure that the target node still has both published and draft versions.
+    # Make sure that the target node still has both published and draft versions.
     Then I should see "View draft"
-    Then I should see "view published"
+    And I should see "view published"
+    # Go back, Jack, do it again.
+    When I click "Translate"
+    And I click "English page two"
+    And I click "XLIFF"
+    And I attach a "fr" translation of this "English" node
+    And I press the "Import" button
+    And I click "Translate"
+    And I click "fr page two"
+    # Make sure that the target node still has both published and draft versions.
+    Then I should see "View draft"
+    And I should see "view published"
 
-  Scenario: Import net new should follow the default moderation state
+  Scenario: Import Net-new should follow the default moderation state
     # Make a new node to avoid the registered callback that worbench sets.
     # It will only be exectured after the scenario file exits.
     Given I am on the homepage
@@ -108,9 +119,10 @@ Feature: Workbench Moderation Feature
     And I press the "Import" button
     And I click "Translate"
     And I click "de page four"
-      # Make sure the new target has NOT been published.
+    # Make sure the new target has NOT been published.
     Then I should see "View draft"
-    Then I should not see "View published"
-    Given I switch page default moderation To published
+    And I should not see "View published"
+    # Reset the page default state.
+    And I switch page default moderation To published
 
 

--- a/test/Features/contentTranslation/WorkbenchModerationIntegration.feature
+++ b/test/Features/contentTranslation/WorkbenchModerationIntegration.feature
@@ -5,6 +5,9 @@ Feature: Workbench Moderation Feature
   Import and export XLIFF translations while using workbench moderation features
 
   Background:
+    # Make sure a failed test has not left page in draft default
+    Given I switch page default moderation To published
+
     Given I am logged in as a user with the "administer entity xliff,bypass node access,bypass workbench moderation,view moderation history,translate content" permission
     And I am on the homepage
     And I click "Add content"
@@ -73,7 +76,7 @@ Feature: Workbench Moderation Feature
     Then I should see "View draft"
     Then I should see "view published"
 
-  Scenario: Import should follow the default moderation state
+  Scenario: Import net new should follow the default moderation state
     # Make a new node to avoid the registered callback that worbench sets.
     # It will only be exectured after the scenario file exits.
     Given I am on the homepage
@@ -90,5 +93,24 @@ Feature: Workbench Moderation Feature
     And I click "de page three"
       # Make sure the new target has been published.
     Then I should see "View published"
+
+    # Now check with default draft
+    Given I switch page default moderation To draft
+    Given I am on the homepage
+    And I click "Add content"
+    And I click "Basic page"
+    And I fill in "English page four" for "title"
+    And I fill in "This page is English in a published state." for "Long Text"
+    And I select "English" from "Language"
+    And I press the "Save" button
+    And I click "XLIFF"
+    And I attach a "de" translation of this "English" node
+    And I press the "Import" button
+    And I click "Translate"
+    And I click "de page four"
+      # Make sure the new target has NOT been published.
+    Then I should see "View draft"
+    Then I should not see "View published"
+    Given I switch page default moderation To published
 
 


### PR DESCRIPTION
Discovered that recent changes had created a situation where paragraphs content was being lost.
Basically there was an extra node save that was overwriting paragraphs fields and saving the wrong revision information.