### PR TITLE
Fix 7.x-1.x build errors/failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ matrix:
 before_install:
   # Update composer
   - composer self-update
+  - phpenv config-add test/travis.php.ini
 
 install:
   # Install requisite PHP libraries.

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
 before_install:
   # Update composer
   - composer self-update
-  - phpenv config-add test/travis.php.ini
+  - if [ $BDD = 'true' ] ; then phpenv config-add test/travis.php.ini ; fi
 
 install:
   # Install requisite PHP libraries.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: trusty
 sudo: false
 
 env:

--- a/test/travis.php.ini
+++ b/test/travis.php.ini
@@ -1,0 +1,1 @@
+memory_limit = 2048M


### PR DESCRIPTION
- Pins Travis builds to Ubuntu Trusty over Precise to work around [this upgrade](https://status.fastly.com/incidents/4n5jrrhh5fyh) affecting *.drupal.org domains.
- Doubles memory available to PHP to mitigate composer "out of memory" fatal errors.