### PR TITLE
noise reduction

### DIFF
--- a/modules/workbench_moderation.entity_xliff.inc
+++ b/modules/workbench_moderation.entity_xliff.inc
@@ -107,9 +107,12 @@ if (!function_exists('workbench_moderation_entity_xliff_presave_alter')) {
         }
       }
       else {
-        // This is a brand new target, remove any workbench stuff left from the source.
+        // This is a brand new target, remove the workbench array left from the source.
         // Force it to follow the default that is set in workbench.
         unset($node->workbench_moderation);
+        // Workbench_moderation will think this is not a new node unless we set both the _current AND the _new states.
+        // See workbench_moderation_node_update($node).
+        $node->workbench_moderation_state_current = variable_get('workbench_moderation_default_state_' . $node->type, workbench_moderation_state_none());
         $node->workbench_moderation_state_new = variable_get('workbench_moderation_default_state_' . $node->type, workbench_moderation_state_none());
       }
 

--- a/src/Drupal/Translatable/EntityTranslatableBase.php
+++ b/src/Drupal/Translatable/EntityTranslatableBase.php
@@ -202,6 +202,10 @@ abstract class EntityTranslatableBase implements EntityTranslatableInterface  {
       $this->drupal->alter('entity_xliff_presave', $wrapper, $type);
       $translatable->saveWrapper($wrapper, $targetLanguage);
     }
+    // Reinitialize the entitiesNeedSave array in case we have multiple xliff files
+    // to process in the same request.
+    $this->entitiesNeedSave = array();
+
   }
 
   /**

--- a/test/scripts/install_drupal.sh
+++ b/test/scripts/install_drupal.sh
@@ -43,7 +43,7 @@ rsync -aq "`pwd`" "`pwd`/$BUILD_DIR/drupal/sites/all/modules/entity_xliff" --exc
 # pin entity-7.x-1.7 until this gets fixed: https://www.drupal.org/node/2807275
 # Pin references-7.x-2.1 since the module is unsupported due to unresolved security issues.
 pushd $BUILD_DIR/drupal
-  drush --yes dl composer-8.x-1.2 composer_manager link entity-7.x-1.7 field_collection paragraphs entityreference entity_translation-7.x-1.0-beta5 references-7.x-2.1 workbench_moderation-7.x-1.4
+  drush --yes dl composer-8.x-1.2 composer_manager link entity-7.x-1.7 field_collection paragraphs entityreference entity_translation references-7.x-2.1 workbench_moderation-7.x-1.4
 
   drush --yes en composer_manager translation entity_translation link field_collection paragraphs_i18n entityreference node_reference workbench_moderation 
   drush cc drush

--- a/test/scripts/install_drupal.sh
+++ b/test/scripts/install_drupal.sh
@@ -45,7 +45,7 @@ rsync -aq "`pwd`" "`pwd`/$BUILD_DIR/drupal/sites/all/modules/entity_xliff" --exc
 pushd $BUILD_DIR/drupal
   drush --yes dl composer-8.x-1.2 composer_manager link entity-7.x-1.7 field_collection paragraphs entityreference entity_translation-7.x-1.0-beta5 references-7.x-2.1 workbench_moderation-7.x-1.4
 
-  drush --yes en  composer_manager translation link  field_collection paragraphs_i18n entityreference node_reference workbench_moderation entity_translation
+  drush --yes en composer_manager translation entity_translation link field_collection paragraphs_i18n entityreference node_reference workbench_moderation 
   drush cc drush
   drush --yes en entity_xliff
   drush cc all

--- a/test/scripts/install_drupal.sh
+++ b/test/scripts/install_drupal.sh
@@ -43,7 +43,7 @@ rsync -aq "`pwd`" "`pwd`/$BUILD_DIR/drupal/sites/all/modules/entity_xliff" --exc
 # pin entity-7.x-1.7 until this gets fixed: https://www.drupal.org/node/2807275
 # Pin references-7.x-2.1 since the module is unsupported due to unresolved security issues.
 pushd $BUILD_DIR/drupal
-  drush --yes dl composer-8.x-1.2 composer_manager link entity-7.x-1.7 field_collection paragraphs entityreference entity_translation references-7.x-2.1 workbench_moderation-7.x-1.4
+  drush --yes dl composer-8.x-1.2 composer_manager link entity-7.x-1.7 field_collection paragraphs entityreference entity_translation-7.x-1.0-beta5 references-7.x-2.1 workbench_moderation-7.x-1.4
 
   drush --yes en  composer_manager translation link  field_collection paragraphs_i18n entityreference node_reference workbench_moderation entity_translation
   drush cc drush


### PR DESCRIPTION
When importing through the UI if there are multiple language files then the translations may get saved multiple times. Also fix notice from workbench_moderation when saving a translation in a new language or any net-new content.